### PR TITLE
Feat: 録音機能を実装

### DIFF
--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -1,0 +1,3 @@
+class VoicesController < ApplicationController
+  def new; end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,14 +3,14 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-import Rails from "@rails/ujs"
-import Turbolinks from "turbolinks"
-import * as ActiveStorage from "@rails/activestorage"
-import "channels"
-import "bootstrap";
-import "../stylesheets/application.scss";
+import Rails from '@rails/ujs';
+import Turbolinks from 'turbolinks';
+import * as ActiveStorage from '@rails/activestorage';
+import 'channels';
+import 'bootstrap';
+import '../stylesheets/application.scss';
 import '@fortawesome/fontawesome-free/js/all';
 
-Rails.start()
-Turbolinks.start()
-ActiveStorage.start()
+Rails.start();
+Turbolinks.start();
+ActiveStorage.start();

--- a/app/javascript/packs/recording.js
+++ b/app/javascript/packs/recording.js
@@ -173,13 +173,7 @@ jsStopRecordingButton.onclick = function() {
 };
 
 jsReplayButton.onclick = function() {
-  if (recordedBlobUrl) {
-    jsPlayer.src = recordedBlobUrl;
-    jsPlayer.onended = function() {
-      jsPlayer.pause();
-    };
-    jsPlayer.play();
-  }
+  jsPlayer.play();
 };
 
 jsPlayer.onplay = function() {

--- a/app/javascript/packs/recording.js
+++ b/app/javascript/packs/recording.js
@@ -5,6 +5,7 @@ const jsReplayButton = document.getElementById('js-replay-button');
 const jsStopReplayButton = document.getElementById('js-stop-replay-button');
 const jsPlayer = document.getElementById('js-player');
 const jsDownLoardLink = document.getElementById('js-downloard-link');
+const jsRecordingState = document.getElementById('js-recording-state');
 
 let audioContext = null;
 let stream = null;
@@ -135,6 +136,7 @@ jsStartRecordingButton.onclick = function() {
 
   jsStartRecordingButton.classList.add('d-none');
   jsStopRecordingButton.classList.remove('d-none');
+  jsRecordingState.classList.remove('d-none');
 
   audioData = [];
   audioContext = new AudioContext();
@@ -158,6 +160,7 @@ jsStartRecordingButton.onclick = function() {
 jsStopRecordingButton.onclick = function() {
   jsStopRecordingButton.classList.add('d-none');
   jsReplayButton.classList.remove('d-none');
+  jsRecordingState.classList.add('d-none');
 
   saveAudio();
   jsPlayer.src = recordedBlobUrl;

--- a/app/javascript/packs/recording.js
+++ b/app/javascript/packs/recording.js
@@ -6,6 +6,7 @@ const jsStopReplayButton = document.getElementById('js-stop-replay-button');
 const jsPlayer = document.getElementById('js-player');
 const jsDownLoardLink = document.getElementById('js-downloard-link');
 const jsRecordingState = document.getElementById('js-recording-state');
+const jsResetButton = document.getElementById('js-reset-button');
 
 let audioContext = null;
 let stream = null;
@@ -161,6 +162,7 @@ jsStopRecordingButton.onclick = function() {
   jsStopRecordingButton.classList.add('d-none');
   jsReplayButton.classList.remove('d-none');
   jsRecordingState.classList.add('d-none');
+  jsResetButton.classList.remove('d-none');
 
   saveAudio();
   jsPlayer.src = recordedBlobUrl;
@@ -198,4 +200,15 @@ jsPlayer.onpause = function() {
 
 jsStopReplayButton.onclick = function() {
   jsPlayer.pause();
+};
+
+jsResetButton.onclick = function() {
+  jsPlayer.src = '';
+
+  jsStartRecordingButton.classList.remove('d-none');
+  jsResetButton.classList.add('d-none');
+  jsReplayButton.classList.add('d-none');
+
+  jsStartRecordingButton.disabled = false;
+  jsReplayButton.disabled = true;
 };

--- a/app/javascript/packs/recording.js
+++ b/app/javascript/packs/recording.js
@@ -160,6 +160,8 @@ jsStopRecordingButton.onclick = function() {
   jsReplayButton.classList.remove('d-none');
 
   saveAudio();
+  jsPlayer.src = recordedBlobUrl;
+
   jsStartRecordingButton.disabled = false;
   jsStopRecordingButton.disabled = true;
   jsReplayButton.disabled = false;
@@ -170,8 +172,27 @@ jsReplayButton.onclick = function() {
     jsPlayer.src = recordedBlobUrl;
     jsPlayer.onended = function() {
       jsPlayer.pause();
-      jsPlayer.src = '';
     };
     jsPlayer.play();
   }
+};
+
+jsPlayer.onplay = function() {
+  jsReplayButton.classList.add('d-none');
+  jsStopReplayButton.classList.remove('d-none');
+
+  jsReplayButton.disabled = true;
+  jsStopReplayButton.disabled = false;
+};
+
+jsPlayer.onpause = function() {
+  jsReplayButton.classList.remove('d-none');
+  jsStopReplayButton.classList.add('d-none');
+
+  jsReplayButton.disabled = false;
+  jsStopReplayButton.disabled = true;
+};
+
+jsStopReplayButton.onclick = function() {
+  jsPlayer.pause();
 };

--- a/app/javascript/packs/recording.js
+++ b/app/javascript/packs/recording.js
@@ -1,0 +1,177 @@
+const jsPermitionButton = document.getElementById('js-mic-permition-button');
+const jsStartRecordingButton = document.getElementById('js-recording-start-button');
+const jsStopRecordingButton = document.getElementById('js-recording-stop-button');
+const jsReplayButton = document.getElementById('js-replay-button');
+const jsStopReplayButton = document.getElementById('js-stop-replay-button');
+const jsPlayer = document.getElementById('js-player');
+const jsDownLoardLink = document.getElementById('js-downloard-link');
+
+let audioContext = null;
+let stream = null;
+let bufferSize = 1024;
+let audioSampleRate = null;
+let scriptProcessor = null;
+let mediaStreamSource = null;
+let audioData = [];
+let timeout = null;
+let recordedBlobUrl = null;
+
+function onAudioProcess(e) {
+  let input = e.inputBuffer.getChannelData(0);
+  let bufferData = new Float32Array(bufferSize);
+  for (let i = 0; i < bufferSize; i++) {
+    bufferData[i] = input[i];
+  }
+  audioData.push(bufferData);
+} 
+
+function exportWAV(audioData) {
+  let encodeWAV = function(samples, sampleRate) {
+    let buffer = new ArrayBuffer(44 + samples.length * 2);
+    let view = new DataView(buffer);
+
+    let writeString = function(view, offset, string) {
+      for (let i = 0; i < string.length; i++) {
+        view.setUint8(offset + i, string.charCodeAt(i));
+      }
+    };
+
+    let floatTo16BitPCM = function(output, offset, input) {
+      for (let i = 0; i < input.length; i++, offset += 2) {
+        let s = Math.max(-1, Math.min(1, input[i]));
+        output.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7FFF, true);
+      }
+    };
+
+    writeString(view, 0, 'RIFF');
+    view.setUint32(4, 32 + samples.length * 2, true);
+    writeString(view, 8, 'WAVE');
+    writeString(view, 12, 'fmt ');
+    view.setUint32(16, 16, true);
+    view.setUint16(20, 1, true);
+    view.setUint16(22, 1, true);
+    view.setUint32(24, sampleRate, true);
+    view.setUint32(28, sampleRate * 2, true);
+    view.setUint16(32, 2, true);
+    view.setUint16(34, 16, true);
+    writeString(view, 36, 'data');
+    view.setUint32(40, samples.length * 2, true);
+    floatTo16BitPCM(view, 44, samples);
+    return view;
+  };
+
+  let mergeBuffers = function(audioData) {
+    let sampleLength = 0;
+    for (let i = 0; i < audioData.length; i++) {
+      sampleLength += audioData[i].length;
+    }
+    let samples = new Float32Array(sampleLength);
+    let sampleIdx = 0;
+    for (let i = 0; i < audioData.length; i++) {
+      for (let j = 0; j < audioData[i].length; j++) {
+        samples[sampleIdx] = audioData[i][j];
+        sampleIdx++;
+      }
+    }
+    return samples;
+  };
+
+  let dataview = encodeWAV(mergeBuffers(audioData), audioSampleRate);
+  let audioBlob = new Blob([dataview], {type: 'audio/wav'});
+  recordedBlobUrl = window.URL.createObjectURL(audioBlob);
+  console.log(dataview);
+
+  let myURL = window.URL || window.webkitURL;
+  let url = myURL.createObjectURL(audioBlob);
+  jsDownLoardLink.href = url;
+}
+
+function saveAudio() {
+  exportWAV(audioData);
+  jsDownLoardLink.downloard = 'voice.wav';
+  audioContext.close().then(function() {
+  });
+}
+
+jsPermitionButton.onclick = function() {
+  jsPlayer.src = '';
+  if(!stream) {
+    navigator.mediaDevices.getUserMedia({
+      video: false,
+      audio: {
+        echoCancellation: true,
+        echoCancellationType: 'system',
+        noiseSuppression: false
+      }
+    })
+      .then(function(audio) {
+        jsPermitionButton.classList.add('d-none');
+        jsStartRecordingButton.classList.remove('d-none');
+
+        stream = audio;
+        console.log('録音可能です');
+        return stream;
+      })
+      .catch(function(error) {
+        console.error('mediaDevide.getUserMedia() error:', error);
+        return;
+      });
+  }
+
+  jsPermitionButton.disabled = true;
+  jsStartRecordingButton.disabled = false;
+  jsStopRecordingButton.disabled = true;
+  jsReplayButton.disabled = true;
+  jsStopReplayButton.disabled = true;
+};
+
+jsStartRecordingButton.onclick = function() {
+  jsPlayer.src = '';
+
+  jsStartRecordingButton.disabled = true;
+  jsStopRecordingButton.disabled = false;
+  jsReplayButton.disabled = true;
+  jsStopReplayButton.disabled = true;
+
+  jsStartRecordingButton.classList.add('d-none');
+  jsStopRecordingButton.classList.remove('d-none');
+
+  audioData = [];
+  audioContext = new AudioContext();
+  audioSampleRate = audioContext.sampleRate;
+  scriptProcessor = audioContext.createScriptProcessor(bufferSize, 2, 2);
+  mediaStreamSource = audioContext.createMediaStreamSource(stream);
+  mediaStreamSource.connect(scriptProcessor);
+  scriptProcessor.onaudioprocess = onAudioProcess;
+  scriptProcessor.connect(audioContext.destination);
+
+  timeout = setTimeout(() => {
+    jsStopRecordingButton.click();
+  }, 30000);
+
+  jsStopRecordingButton.addEventListener('click', () => {
+    clearTimeout(timeout);
+    console.log('録音停止しました');
+  });
+};
+
+jsStopRecordingButton.onclick = function() {
+  jsStopRecordingButton.classList.add('d-none');
+  jsReplayButton.classList.remove('d-none');
+
+  saveAudio();
+  jsStartRecordingButton.disabled = false;
+  jsStopRecordingButton.disabled = true;
+  jsReplayButton.disabled = false;
+};
+
+jsReplayButton.onclick = function() {
+  if (recordedBlobUrl) {
+    jsPlayer.src = recordedBlobUrl;
+    jsPlayer.onended = function() {
+      jsPlayer.pause();
+      jsPlayer.src = '';
+    };
+    jsPlayer.play();
+  }
+};

--- a/app/views/voices/new.html.erb
+++ b/app/views/voices/new.html.erb
@@ -12,6 +12,9 @@
     <button id="js-replay-button" class="btn btn-primary rounded-pill d-none">音声再生</button>
     <button id="js-stop-replay-button" class="btn btn-primary rounded-pill d-none">再生停止</button>
   </div>
+  <div class="d-flex justify-content-center py-2">
+    <button id="js-reset-button" class="btn btn-primary rounded-pill d-none">録り直す</button>
+  </div>
 </div>
 
 <%= javascript_pack_tag 'recording' %>

--- a/app/views/voices/new.html.erb
+++ b/app/views/voices/new.html.erb
@@ -1,0 +1,16 @@
+<div class="container-fluid bg-dark text-white">
+  <h1 class="text-center py-4">録音・加工する</h1>
+  <div class="d-flex justify-content-center py-4">
+    <audio id="js-player" controls></audio>
+    <a id="js-downloard-link" type="hidden"></a>
+  </div>
+  <div class="d-flex justify-content-center py-4">
+    <button id="js-mic-permition-button" class="btn btn-primary rounded-pill">マイク許可</button>
+    <button id="js-recording-start-button" class="btn btn-primary rounded-pill d-none">録音開始</button>
+    <button id="js-recording-stop-button" class="btn btn-primary rounded-pill d-none">録音停止</button>
+    <button id="js-replay-button" class="btn btn-primary rounded-pill d-none">音声再生</button>
+    <button id="js-stop-replay-button" class="btn btn-primary rounded-pill d-none">再生停止</button>
+  </div>
+</div>
+
+<%= javascript_pack_tag 'recording' %>

--- a/app/views/voices/new.html.erb
+++ b/app/views/voices/new.html.erb
@@ -4,6 +4,7 @@
     <audio id="js-player" controls></audio>
     <a id="js-downloard-link" type="hidden"></a>
   </div>
+  <div id="js-recording-state" class="text-center d-none">Now Recording ...</div>
   <div class="d-flex justify-content-center py-4">
     <button id="js-mic-permition-button" class="btn btn-primary rounded-pill">マイク許可</button>
     <button id="js-recording-start-button" class="btn btn-primary rounded-pill d-none">録音開始</button>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
+  resources :voices
 end

--- a/spec/requests/voices_spec.rb
+++ b/spec/requests/voices_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Voices", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 概要
ブラウザ上で音声を録音する機能を実装しました。
audioにcontrolsを指定すれば音声の再生・停止自体は可能だが、スマホなどでも操作しやすくするために録音した音声を再生・一時停止できるボタンを設置。
録り直すボタンを設置。
録音中はわかりやすいようにNow Recording ...と表示するようにしました。

![image](https://user-images.githubusercontent.com/87419889/169629610-bbe48f55-cb5f-4f7d-82e5-b46b87741a40.png)

![image](https://user-images.githubusercontent.com/87419889/169629621-e09a1be5-f4bc-4673-9ccd-14dda3bf9b32.png)

![image](https://user-images.githubusercontent.com/87419889/169629634-110539bb-9a44-4bf7-b709-c15a8ff1d4dc.png)

![image](https://user-images.githubusercontent.com/87419889/169629639-f63ac99f-5dd0-4f17-aedb-454cb86ab422.png)


close #17 

## 備考
eslintとrubocopの指摘事項なし。