### PR TITLE
非ログインユーザーの場合ゲストユーザーとして録音した音声を保存できる機能を実装

### DIFF
--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -2,7 +2,19 @@ class VoicesController < ApplicationController
   def new; end
 
   def create
-    voice = current_user.voices.build(voice_params) if logged_in?
+    if logged_in?
+      voice = current_user.voices.build(voice_params)
+    else
+      random_value = SecureRandom.hex
+      guest_user = User.create!(
+        name: "ゲストユーザー",
+        email: "guest_#{random_value}@example.com",
+        password: random_value,
+        password_confirmation: random_value,
+        role: :guest
+      )
+      voice = guest_user.voices.build(voice_params)
+    end
 
     if voice.save
       render json: { url: root_url }

--- a/app/javascript/packs/recording.js
+++ b/app/javascript/packs/recording.js
@@ -242,6 +242,7 @@ jsResetButton.onclick = function() {
   jsResetButton.classList.add('d-none');
   jsReplayButton.classList.add('d-none');
   jsStopReplayButton.classList.add('d-none');
+  jsVoiceSaveButton.classList.add('d-none');
 
   jsStartRecordingButton.disabled = false;
   jsReplayButton.disabled = true;

--- a/app/javascript/packs/recording.js
+++ b/app/javascript/packs/recording.js
@@ -9,7 +9,7 @@ const jsStopRecordingButton = document.getElementById('js-recording-stop-button'
 const jsReplayButton = document.getElementById('js-replay-button');
 const jsStopReplayButton = document.getElementById('js-stop-replay-button');
 const jsPlayer = document.getElementById('js-player');
-const jsDownLoardLink = document.getElementById('js-download-link');
+const jsDownLoadLink = document.getElementById('js-download-link');
 const jsRecordingState = document.getElementById('js-recording-state');
 const jsResetButton = document.getElementById('js-reset-button');
 const jsVoiceSaveButton = document.getElementById('js-voice-save-button');
@@ -90,12 +90,12 @@ function exportWAV(audioData) {
 
   let myURL = window.URL || window.webkitURL;
   let url = myURL.createObjectURL(audioBlob);
-  jsDownLoardLink.href = url;
+  jsDownLoadLink.href = url;
 }
 
 function saveAudio() {
   exportWAV(audioData);
-  jsDownLoardLink.downloard = 'voice.wav';
+  jsDownLoadLink.downloard = 'voice.wav';
   audioContext.close().then(function() {
   });
 }
@@ -251,7 +251,7 @@ jsResetButton.onclick = function() {
 jsVoiceSaveButton.onclick = function() {
   jsVoiceSaveButton.disabled = true;
   var xhr = new XMLHttpRequest();
-  xhr.open('GET', document.querySelector('#js-download-link').href, true);
+  xhr.open('GET', jsDownLoadLink.href, true);
   xhr.responseType = 'blob';
   xhr.send();
   xhr.onload = function() {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,5 +9,5 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
   validates :name, presence: true, length: { maximum: 30 }
 
-  enum role: { general: 0, admin: 1 }
+  enum role: { general: 0, admin: 1, guest: 2 }
 end

--- a/app/views/voices/new.html.erb
+++ b/app/views/voices/new.html.erb
@@ -26,8 +26,7 @@
   <% if logged_in? %>
     <button id="js-voice-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none"><%= (t '.save_as_logged_in_user') %></button>
   <% else %>
-    <button id="js-voice-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none"><%= (t '.signin_and_share') %></button>
-    <button id="js-voice-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none"><%= (t '.share_only') %></button>
+    <button id="js-voice-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none"><%= (t '.to_share') %></button>
   <% end %>
 </div>
 

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -20,6 +20,7 @@ ja:
       role:
         general: '一般'
         admin: '管理者'
+        guest: 'ゲスト'
     voice:
       status:
         open: '公開'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -37,8 +37,7 @@ ja:
       stop_replay: '再生停止'
       reset: '取り直す'
       save_as_logged_in_user: '保存してシェア画面へ'
-      signin_and_share: 'ユーザー登録してシェア'
-      share_only: 'ユーザー登録せずシェア'
+      to_share: 'シェア画面へ'
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'


### PR DESCRIPTION
## 概要
非ログインユーザーが録音した音声をゲストユーザーとして保存可能にするため、createアクション内で都度ゲストユーザーを作成し、そのゲストユーザーに紐づけるという方法を採りました。
ゲストログインではなく、あくまでゲストユーザーとして保存ができる機能です。

その他タイポの修正・まだ実装しない機能(#42 )で必要になる2つのボタン「ユーザー登録してシェア」と「ユーザー登録せずシェア」を一旦削除し、保存のみ実行する為のボタンを設置を行いました。
※ボタンの文言にシェアという言葉が入っていますが、保存成功時に詳細画面へ遷移させるためのボタンです。詳細画面にTwitterでシェアするためのボタンを設置予定です。

実装方法は以下で考察し
[PF 音声保存処理とユーザーのidとの紐付け](https://ripe-kayak-b03.notion.site/PF-id-b5b3bb67803e419c9cdd98f463b9b1ac)
実装過程については以下にまとめています。
[ゲストユーザーが録音した音声を保存できるようにする](https://ripe-kayak-b03.notion.site/241033645e014e5fb77277eb9644efe9)

close #39 

## 確認方法
1. ログインせずに、`http://localhost:3000/voices/new`にアクセスします。(ログインしている場合はログアウト後にアクセス)
2. 音声を録音し、内容を入力後「シェア画面へ」ボタンを押します。
3. 保存が成功した場合は`http://localhost:3000`へリダイレクトされます。
4. 保存失敗時は`http://localhost:3000/voices/new`がリクエストされます。

## コメント
今後のVoicesテーブル関連の実装の流れをまとめておきます。
1. 詳細画面、編集機能の作成
2. 保存失敗時の次善策を実装
3. 一覧画面を作成

**保存失敗時の次善策については以下を参照**
[次善策](https://www.notion.so/PF-7654bde3f20c4a89a6a5c9425082049e#c9fe55eb4bed4deaa7ead1cee64d0910)
[バリデーション失敗時の次善策の実装方法を考える！](https://www.notion.so/241033645e014e5fb77277eb9644efe9#faa68850b1fb443db1d29d6ae662235f)
