### PR TITLE
音声詳細ページと削除機能の作成

### DIFF
--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -1,6 +1,10 @@
 class VoicesController < ApplicationController
   def new; end
 
+  def show
+    @voice = Voice.find(params[:id])
+  end
+
   def create
     if logged_in?
       voice = current_user.voices.build(voice_params)
@@ -17,7 +21,7 @@ class VoicesController < ApplicationController
     end
 
     if voice.save
-      render json: { url: root_url }
+      render json: { url: voice_path(voice) }
     else
       render json: { url: new_voice_path }
     end

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -7,7 +7,7 @@ class VoicesController < ApplicationController
     else
       random_value = SecureRandom.hex
       guest_user = User.create!(
-        name: "ゲストユーザー",
+        name: 'ゲストユーザー',
         email: "guest_#{random_value}@example.com",
         password: random_value,
         password_confirmation: random_value,

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -27,6 +27,12 @@ class VoicesController < ApplicationController
     end
   end
 
+  def destroy
+    voice = current_user.voices.find(params[:id])
+    voice.destroy!
+    redirect_to root_url, dark: '音声を削除しました'
+  end
+
   private
 
   def set_voice

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -1,9 +1,9 @@
 class VoicesController < ApplicationController
+  before_action :set_voice, only: %[show]
+
   def new; end
 
-  def show
-    @voice = Voice.find(params[:id])
-  end
+  def show; end
 
   def create
     if logged_in?
@@ -28,6 +28,10 @@ class VoicesController < ApplicationController
   end
 
   private
+
+  def set_voice
+    @voice = Voice.find(params[:id])
+  end
 
   def voice_params
     params.permit(:growl_voice, :description)

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -1,5 +1,5 @@
 class VoicesController < ApplicationController
-  before_action :set_voice, only: %[show]
+  before_action :set_voice, only: %(show)
 
   def new; end
 

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -30,7 +30,7 @@ class VoicesController < ApplicationController
   def destroy
     voice = current_user.voices.find(params[:id])
     voice.destroy!
-    redirect_to root_url, dark: '音声を削除しました'
+    redirect_to root_url, dark: t('defaults.message.deleted', item: Voice.model_name.human)
   end
 
   private

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -21,7 +21,7 @@
             <% end %>
           </div>
           <div class="mx-3">
-            <%= link_to voice_path(@voice), method: :delete, data: { confirm: '本当に削除しますか？' } do %>
+            <%= link_to voice_path(@voice), method: :delete, data: { confirm: (t 'defaults.message.delete_confirm') } do %>
             <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i> <%= (t '.to_delete') %></button>
             <% end %>
           </div>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -13,18 +13,20 @@
         <% end %>
       </div>
       <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-show-page-player') %>
-      <div class="m-3 d-flex justify-content-center">
-        <div class="mx-3">
-          <%= link_to '#' do %>
-            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i> <%= (t '.to_edit') %></button>
-          <% end %>
+      <% if logged_in? && @voice.user_id == current_user.id %>
+        <div class="m-3 d-flex justify-content-center">
+          <div class="mx-3">
+            <%= link_to '#' do %>
+              <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i> <%= (t '.to_edit') %></button>
+            <% end %>
+          </div>
+          <div class="mx-3">
+            <%= link_to '#' do %>
+            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i> <%= (t '.to_delete') %></button>
+            <% end %>
+          </div>
         </div>
-        <div class="mx-3">
-          <%= link_to '#' do %>
-          <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i> <%= (t '.to_delete') %></button>
-        <% end %>
-        </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -1,0 +1,18 @@
+<div class="container-fluid bg-dark text-white">
+  <div class="d-flex justify-content-center text-center">
+    <div class="">
+      <div class="mt-5 mb-4 h3">
+        <%= Voice.human_attribute_name(:description) %>
+      </div>
+      <div class="mb-4 h4 text-break">
+        <%= @voice.description %>
+      </div>
+      <div class="mb-4 h5 text-break">
+        <%= (t '.by') %><%= @voice.user.name %>
+      </div>
+      <div class="">
+        <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-show-page-player') %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -8,7 +8,9 @@
         <%= @voice.description %>
       </div>
       <div class="mb-4 h5 text-break">
-        <%= (t '.by') %><%= @voice.user.name %>
+        <% unless @voice.user.role == "guest" %>
+          <%= (t '.by') %><%= @voice.user.name %>
+        <% end %>
       </div>
       <div class="">
         <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-show-page-player') %>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container-fluid bg-dark text-white">
   <div class="d-flex justify-content-center text-center">
-    <div class="">
+    <div>
       <div class="mt-5 mb-4 h3">
         <%= Voice.human_attribute_name(:description) %>
       </div>
@@ -12,9 +12,7 @@
           <%= (t '.by') %><%= @voice.user.name %>
         <% end %>
       </div>
-      <div class="">
-        <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-show-page-player') %>
-      </div>
+      <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-show-page-player') %>
       <div class="m-3 d-flex justify-content-center">
         <div class="mx-3">
           <%= link_to '#' do %>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -15,6 +15,18 @@
       <div class="">
         <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-show-page-player') %>
       </div>
+      <div class="m-3 d-flex justify-content-center">
+        <div class="mx-3">
+          <%= link_to '#' do %>
+            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i> 編集</button>
+          <% end %>
+        </div>
+        <div class="mx-3">
+          <%= link_to '#' do %>
+          <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i> 削除</button>
+        <% end %>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -18,12 +18,12 @@
       <div class="m-3 d-flex justify-content-center">
         <div class="mx-3">
           <%= link_to '#' do %>
-            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i> 編集</button>
+            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i> <%= (t '.to_edit') %></button>
           <% end %>
         </div>
         <div class="mx-3">
           <%= link_to '#' do %>
-          <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i> 削除</button>
+          <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i> <%= (t '.to_delete') %></button>
         <% end %>
         </div>
       </div>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -21,7 +21,7 @@
             <% end %>
           </div>
           <div class="mx-3">
-            <%= link_to '#' do %>
+            <%= link_to voice_path(@voice), method: :delete, data: { confirm: '本当に削除しますか？' } do %>
             <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i> <%= (t '.to_delete') %></button>
             <% end %>
           </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -40,6 +40,8 @@ ja:
       to_share: 'シェア画面へ'
     show:
       by: 'By '
+      to_edit: '編集'
+      to_delete: '削除'
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -38,6 +38,8 @@ ja:
       reset: '取り直す'
       save_as_logged_in_user: '保存してシェア画面へ'
       to_share: 'シェア画面へ'
+    show:
+      by: 'By '
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -12,6 +12,9 @@ ja:
     privacy_policy: 'プライバシーポリシー'
     inquiry: 'お問い合わせ'
     copyright: 'Copyright © 2022. デスボイスチェンジャー'
+    message:
+      deleted: "%{item}を削除しました"
+      delete_confirm: '本当に削除しますか？'
   users:
     new:
       title: 'ユーザー登録'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :voices, only: %i[new create show]
+  resources :voices, only: %i[new create show destroy]
 end


### PR DESCRIPTION
## 概要
音声の詳細ページを作成しました。大まかにですがデザインは整えています。
![image](https://user-images.githubusercontent.com/87419889/176700333-b83990b1-14fa-43ed-882e-3a810c7c44e6.png)
表示されている音声の作成者以外には編集ボタンと削除ボタンは表示されません。 5dfea9e 
ゲストユーザーの音声は作成者の名前は表示されません。 54cca70 

削除ボタンは今のところ詳細ページにのみ表示する予定なので、このIssueで削除機能も作成しています。 cf79549 93e3628 

close #40

## 確認方法
1. ログインし音声を作成します。
2. 保存が成功すると詳細画面へ遷移します。
3. 上のスクリーンショットのように、内容とユーザー名が表示され、音声を再生することを確認してください。
4. 削除ボタンを押した時「本当に削除しますか?」というconfirmが表示されることを確認してください。
5. confirmを受け入れると、トップページが表示され「音声を削除しました」というフラッシュメッセージが表示されることを確認してください。

## コメント
編集ボタンへのリンク先はまだ指定していません。
音声を削除した後トップページにリダイレクトさせるように設定していますが、後でリダイレクト先を変更する可能性があります。
録音画面のように音声を再生するためのボタンは設置せず、オーディオのcontrolsで操作するようにしていますが、もし要望などがあれば再生ボタン等の設置を検討します。