### PR TITLE
編集機能を実装

### DIFF
--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -1,5 +1,5 @@
 class VoicesController < ApplicationController
-  before_action :set_voice, only: %(show)
+  before_action :set_voice, only: %i[show]
 
   def new; end
 

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -34,9 +34,9 @@ class VoicesController < ApplicationController
   def update
     @voice = current_user.voices.find(params[:id])
     if @voice.update(voice_params_for_update)
-      redirect_to @voice, dark: '内容を更新しました'
+      redirect_to @voice, dark: t('defaults.message.updated', item: Voice.human_attribute_name(:description))
     else
-      flash.now[:danger] = '内容を更新できませんでした'
+      flash.now[:danger] = t('defaults.message.not_updated', item: Voice.human_attribute_name(:description))
       render :edit
     end
   end

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -27,6 +27,10 @@ class VoicesController < ApplicationController
     end
   end
 
+  def edit
+    @voice = current_user.voices.find(params[:id])
+  end
+
   def destroy
     voice = current_user.voices.find(params[:id])
     voice.destroy!

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -31,6 +31,16 @@ class VoicesController < ApplicationController
     @voice = current_user.voices.find(params[:id])
   end
 
+  def update
+    @voice = current_user.voices.find(params[:id])
+    if @voice.update(voice_params_for_update)
+      redirect_to @voice, dark: '内容を更新しました'
+    else
+      flash.now[:danger] = '内容を更新できませんでした'
+      render :edit
+    end
+  end
+
   def destroy
     voice = current_user.voices.find(params[:id])
     voice.destroy!
@@ -45,5 +55,9 @@ class VoicesController < ApplicationController
 
   def voice_params
     params.permit(:growl_voice, :description)
+  end
+
+  def voice_params_for_update
+    params.require(:voice).permit(:description)
   end
 end

--- a/app/views/voices/edit.html.erb
+++ b/app/views/voices/edit.html.erb
@@ -12,7 +12,7 @@
     <%= form_with model: @voice, local: true do |f| %>
       <%= f.label :description, Voice.human_attribute_name(:description) %>
       <%= f.text_field :description, class: 'form-control' %>
-      <%= f.submit '更新する', class: 'btn btn-primary d-block mx-auto rounded-pill text-black my-3' %>
+      <%= f.submit '更新する', class: 'btn btn-primary d-block mx-auto rounded-pill my-3' %>
     <% end %>
   </div>
 </div>

--- a/app/views/voices/edit.html.erb
+++ b/app/views/voices/edit.html.erb
@@ -10,6 +10,7 @@
   </div>
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
     <%= form_with model: @voice, local: true do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
       <%= f.label :description, Voice.human_attribute_name(:description) %>
       <%= f.text_field :description, class: 'form-control' %>
       <%= f.submit (t '.update_button'), class: 'btn btn-primary d-block mx-auto rounded-pill my-3' %>

--- a/app/views/voices/edit.html.erb
+++ b/app/views/voices/edit.html.erb
@@ -1,0 +1,18 @@
+<div class="container-fluid bg-dark text-white">
+  <p class="h2 py-4 d-flex justify-content-center text-center">編集</p>
+  <div class="d-flex justify-content-center">
+    <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-edit-page-player') %>
+  </div>
+  <div class="my-4 h5 text-break text-center">
+    <% unless @voice.user.role == "guest" %>
+      <%= (t '.by') %><%= @voice.user.name %>
+    <% end %>
+  </div>
+  <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
+    <%= form_with model: @voice, local: true do |f| %>
+      <%= f.label :description, Voice.human_attribute_name(:description) %>
+      <%= f.text_field :description, class: 'form-control' %>
+      <%= f.submit '更新する', class: 'btn btn-primary d-block mx-auto rounded-pill text-black my-3' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/voices/edit.html.erb
+++ b/app/views/voices/edit.html.erb
@@ -1,18 +1,18 @@
 <div class="container-fluid bg-dark text-white">
-  <p class="h2 py-4 d-flex justify-content-center text-center">編集</p>
+  <p class="h2 py-4 d-flex justify-content-center text-center"><%= (t '.title') %></p>
   <div class="d-flex justify-content-center">
     <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-edit-page-player') %>
   </div>
   <div class="my-4 h5 text-break text-center">
     <% unless @voice.user.role == "guest" %>
-      <%= (t '.by') %><%= @voice.user.name %>
+      <%= (t '.by') %> <%= @voice.user.name %>
     <% end %>
   </div>
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
     <%= form_with model: @voice, local: true do |f| %>
       <%= f.label :description, Voice.human_attribute_name(:description) %>
       <%= f.text_field :description, class: 'form-control' %>
-      <%= f.submit '更新する', class: 'btn btn-primary d-block mx-auto rounded-pill my-3' %>
+      <%= f.submit (t '.update_button'), class: 'btn btn-primary d-block mx-auto rounded-pill my-3' %>
     <% end %>
   </div>
 </div>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -9,7 +9,7 @@
       </div>
       <div class="mb-4 h5 text-break">
         <% unless @voice.user.role == "guest" %>
-          <%= (t '.by') %><%= @voice.user.name %>
+          <%= (t '.by') %> <%= @voice.user.name %>
         <% end %>
       </div>
       <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-show-page-player') %>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -16,7 +16,7 @@
       <% if logged_in? && @voice.user_id == current_user.id %>
         <div class="m-3 d-flex justify-content-center">
           <div class="mx-3">
-            <%= link_to '#' do %>
+            <%= link_to edit_voice_path(@voice) do %>
               <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i> <%= (t '.to_edit') %></button>
             <% end %>
           </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -13,6 +13,8 @@ ja:
     inquiry: 'お問い合わせ'
     copyright: 'Copyright © 2022. デスボイスチェンジャー'
     message:
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新できませんでした"
       deleted: "%{item}を削除しました"
       delete_confirm: '本当に削除しますか？'
   users:
@@ -45,6 +47,10 @@ ja:
       by: 'By '
       to_edit: '編集'
       to_delete: '削除'
+    edit:
+      title: '編集'
+      by: 'By'
+      update_button: '更新する'
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -44,7 +44,7 @@ ja:
       save_as_logged_in_user: '保存してシェア画面へ'
       to_share: 'シェア画面へ'
     show:
-      by: 'By '
+      by: 'By'
       to_edit: '編集'
       to_delete: '削除'
     edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :voices, only: %i[new create show destroy]
+  resources :voices, only: %i[new create show destroy edit]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :voices, only: %i[new create show destroy edit]
+  resources :voices, only: %i[new create show destroy edit update]
 end


### PR DESCRIPTION
## 概要
編集ページを作成し、音声の「内容(descriptionカラム)」を編集できるようにしました。
編集できるのは音声を作成したログインユーザーのみです。

実装時につけていた記録は以下です。
[編集機能実装時の記録](https://ripe-kayak-b03.notion.site/f4ccfeffca8e419d987076bc88a5cedc)

close #54

## 確認方法
1. サーバーを立ち上げ、ログインします。
2. 自分で作成した音声の詳細ページへアクセスします。
3. 編集ボタンをクリックすると編集ページへ遷移する事を確認してください。
4. 編集ページで内容の入力フィールドに編集前の内容が表示されていることを確認してください。
5. 内容を入力し「更新する」ボタンを押すと、詳細ページへ遷移し更新された内容とフラッシュメッセージが表示されることを確認してください。
6. 内容が未入力の状態で「更新するボタン」を押すと、エラーメッセージとフラッシュメッセージが表示されることを確認してください。

## コメント
その他
- 詳細ページのレイアウトの調整 1ffe612 
- 詳細ページを作成時before_actionのコールバックとして設定した箇所のタイポ修正 e37c78e 

を行なっています。
このコールバックにした箇所は結局showアクションでしか使用しないので、showアクションの中に記述を戻してもいいかもしれません。

updateアクションで使用するストロングパラメーターのメソッド名を`voice_params_for_update`と命名しましたが、他に適切な命名があるかもしれません。
createアクションで使用するストロングパラメーターのメソッド名は`voice_params`のままにしていますが、こちらもわかりやすいように`voice_params_for_create`と変更した方が良いのかもしれません。