### PR TITLE
コンテンツがフッターに隠れてしまうことへの対応

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,8 @@
-<footer class="bg-dark fixed-bottom">
+<% if current_page?(root_path) %>
+  <footer class="bg-dark fixed-bottom">
+<% else %>
+  <footer class="bg-dark sticky-bottom">
+<% end %>
   <div class="container-fluid text-white text-center pt-1">
     <div class="row">
       <%= link_to (t 'defaults.terms_of_services'), '#', class: 'text-white p-1 col text-decoration-none' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,9 +1,9 @@
 <% if current_page?(root_path) %>
-  <footer class="bg-dark fixed-bottom">
+  <footer class="fixed-bottom">
 <% else %>
-  <footer class="bg-dark sticky-bottom">
+  <footer class="sticky-bottom">
 <% end %>
-  <div class="container-fluid text-white text-center pt-1">
+  <div class="container-fluid bg-dark text-white text-center pt-1">
     <div class="row">
       <%= link_to (t 'defaults.terms_of_services'), '#', class: 'text-white p-1 col text-decoration-none' %>
       <%= link_to (t 'defaults.privacy_policy'), '#', class: 'text-white p-1 col text-decoration-none' %>

--- a/app/views/voices/new.html.erb
+++ b/app/views/voices/new.html.erb
@@ -23,11 +23,13 @@
       <%= f.text_field :description, class: 'form-control', id: 'description-form' %>
     <% end %>
   </div>
+  <div class="pb-5">
   <% if logged_in? %>
     <button id="js-voice-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none"><%= (t '.save_as_logged_in_user') %></button>
   <% else %>
     <button id="js-voice-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none"><%= (t '.to_share') %></button>
   <% end %>
+  </div>
 </div>
 
 <%= javascript_pack_tag 'recording' %>

--- a/app/views/voices/new.html.erb
+++ b/app/views/voices/new.html.erb
@@ -24,11 +24,11 @@
     <% end %>
   </div>
   <div class="pb-5">
-  <% if logged_in? %>
-    <button id="js-voice-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none"><%= (t '.save_as_logged_in_user') %></button>
-  <% else %>
-    <button id="js-voice-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none"><%= (t '.to_share') %></button>
-  <% end %>
+    <% if logged_in? %>
+      <button id="js-voice-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none"><%= (t '.save_as_logged_in_user') %></button>
+    <% else %>
+      <button id="js-voice-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none"><%= (t '.to_share') %></button>
+    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
## 概要
ページ内のコンテンツが多くなると、windowサイズのheightが小さすぎる場合にコンテンツにフッターが重なって見えなくなる場合に対処しました。 
変更に伴うレイアウトの崩れも修正しました。 

close #65

## 確認方法
1. サーバーを立ち上げトップページへアクセスし、画面サイズを様々に変えてみてフッターの位置を確認してください。
3. トップページ以外のページ、例えば録音画面やログイン画面、新規登録画面、音声詳細画面へアクセスし画面サイズを様々に変えてみてフッターの位置を確認してください。

## コメント
検討したことなどを以下にまとめています。
[コンテンツがフッターに隠れてしまうことの解消](https://ripe-kayak-b03.notion.site/82164f1bfd5748a9aee39c99f5c38917)

#65では録音画面や今後実装する一覧画面でコンテンツがフッターの下に隠れてしまうことを防ぐのが主な目的なので、
ここで検討している、「フッターをコンテンツが少ない場合はウィンドウの下部、十分なコンテンツがある場合はコンテンツの最下部に配置すること」はこのプルリクでは実装していません。

今回トップページはfixed-bottomのままにしたかったので、トップページかどうかでフッターのクラスを出し分けるように条件分岐させることで対処しましたが、望ましい方法ではないかもしれません。
トップページをfixed-bottomにしたかったのは純粋にデザインの見た目の為と不都合が生じない箇所であった為なので、
今後トップページのデザインを変更する場合に(例えばアプリの説明をトップページに足すなど)
再度変更する可能性があります。