### PR TITLE
音声一覧画面を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'sorcery'
 gem 'carrierwave'
 gem 'fog-aws'
 
+# Pagination
+gem 'pagy'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,8 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    pagy (5.10.1)
+      activesupport
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
@@ -368,6 +370,7 @@ DEPENDENCIES
   fog-aws
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  pagy
   pg (~> 1.1)
   pry-byebug
   pry-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,6 +29,6 @@ body {
   margin: 0;
 }
 
-.bg-gray-color{
+.bg-gray-color {
   background-color: rgb(48, 48, 59) !important;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,3 +32,12 @@ body {
 .bg-gray-color {
   background-color: rgb(48, 48, 59) !important;
 }
+
+.pagination>li>a {
+  border: none;
+  background-color: rgb(48, 48, 59) !important;
+}
+
+.pagination>.active>a {
+  background-color: #f40000 !important;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,7 @@ body {
   padding: 0;
   margin: 0;
 }
+
+.bg-gray-color{
+  background-color: rgb(48, 48, 59) !important;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger, :light, :dark, :secondary
+  include Pagy::Backend
 end

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -48,7 +48,7 @@ class VoicesController < ApplicationController
   def destroy
     voice = current_user.voices.find(params[:id])
     voice.destroy!
-    redirect_to root_url, dark: t('defaults.message.deleted', item: Voice.model_name.human)
+    redirect_to voices_path, dark: t('defaults.message.deleted', item: Voice.model_name.human)
   end
 
   private

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -6,7 +6,7 @@ class VoicesController < ApplicationController
   def show; end
 
   def index
-    @voices = Voice.where(status: :open).includes(:user).order(created_at: :desc)
+    @pagy, @voices = pagy(Voice.where(status: :open).includes(:user).order(created_at: :desc))
   end
 
   def create

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -17,7 +17,7 @@ class VoicesController < ApplicationController
         password_confirmation: random_value,
         role: :guest
       )
-      voice = guest_user.voices.build(voice_params)
+      voice = guest_user.voices.build(voice_params.merge(status: :closed))
     end
 
     if voice.save

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -5,6 +5,10 @@ class VoicesController < ApplicationController
 
   def show; end
 
+  def index
+    @voices = Voice.where(status: :open).includes(:user).order(created_at: :desc)
+  end
+
   def create
     if logged_in?
       voice = current_user.voices.build(voice_params)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+  include Pagy::Frontend
 end

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -13,7 +13,7 @@
             <% end %>
           </li>
           <li class="nav-item">
-            <%= link_to '#', class: 'nav-link' do %>
+            <%= link_to voices_path, class: 'nav-link' do %>
               <i class="fas fa-list-ul"></i><%= (t 'defaults.voices_list') %>
             <% end %>
           </li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,7 +13,7 @@
             <% end %>
           </li>
           <li class="nav-item">
-            <%= link_to '#', class: 'nav-link' do %>
+            <%= link_to voices_path, class: 'nav-link' do %>
               <i class="fas fa-list-ul"></i><%= (t 'defaults.voices_list') %>
             <% end %>
           </li>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -9,7 +9,9 @@
     </div>
     <div class="d-flex justify-content-center">
       <div class="column my-2 mx-3">
-        <button type="button" class="btn btn-dark rounded-pill"><%= (t '.to_voices_list') %></button>
+        <%= link_to voices_path do %>
+          <button type="button" class="btn btn-dark rounded-pill"><%= (t '.to_voices_list') %></button>
+        <% end %>
       </div>
       <div class="column my-2 mx-3">
         <button type="button" class="btn btn-dark rounded-pill"><%= (t '.to_topics_list') %></button>

--- a/app/views/voices/_voice.html.erb
+++ b/app/views/voices/_voice.html.erb
@@ -1,0 +1,14 @@
+<div class="container-fluid">
+  <div class="m-2">
+    <div class="voice-id-<%= voice.id %>">
+      <%= link_to voice_path(voice), class: 'text-decoration-none' do %>
+        <div class="card bg-gray-color text-white border-dark p-3">
+          <div class="card-body">
+            <h4 class="card-title"><%= voice.description %></h4>
+            <p class="card-text">By <%= voice.user.name %></p>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/voices/_voice.html.erb
+++ b/app/views/voices/_voice.html.erb
@@ -6,7 +6,7 @@
           <div class="card-body">
             <h4 class="card-title"><%= voice.description %></h4>
             <% unless voice.user.role == "guest" %>
-              <p class="card-text"><%= (t 'defaults.by') %> <%= voice.user.name %></p>
+              <p class="card-text"><%= (t 'defaults.by') %><%= voice.user.name %></p>
             <% end %>
           </div>
         </div>

--- a/app/views/voices/_voice.html.erb
+++ b/app/views/voices/_voice.html.erb
@@ -5,7 +5,7 @@
         <div class="card bg-gray-color text-white border-dark p-3">
           <div class="card-body">
             <h4 class="card-title"><%= voice.description %></h4>
-            <p class="card-text">By <%= voice.user.name %></p>
+            <p class="card-text"><%= (t 'defaults.by') %> <%= voice.user.name %></p>
           </div>
         </div>
       <% end %>

--- a/app/views/voices/_voice.html.erb
+++ b/app/views/voices/_voice.html.erb
@@ -5,7 +5,9 @@
         <div class="card bg-gray-color text-white border-dark p-3">
           <div class="card-body">
             <h4 class="card-title"><%= voice.description %></h4>
-            <p class="card-text"><%= (t 'defaults.by') %> <%= voice.user.name %></p>
+            <% unless voice.user.role == "guest" %>
+              <p class="card-text"><%= (t 'defaults.by') %> <%= voice.user.name %></p>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/voices/edit.html.erb
+++ b/app/views/voices/edit.html.erb
@@ -5,7 +5,7 @@
   </div>
   <div class="mb-4 h5 text-break text-center">
     <% unless @voice.user.role == "guest" %>
-      <%= (t '.by') %> <%= @voice.user.name %>
+      <%= (t 'defaults.by') %> <%= @voice.user.name %>
     <% end %>
   </div>
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3 pb-4">

--- a/app/views/voices/edit.html.erb
+++ b/app/views/voices/edit.html.erb
@@ -5,7 +5,7 @@
   </div>
   <div class="mb-4 h5 text-break text-center">
     <% unless @voice.user.role == "guest" %>
-      <%= (t 'defaults.by') %> <%= @voice.user.name %>
+      <%= (t 'defaults.by') %><%= @voice.user.name %>
     <% end %>
   </div>
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3 pb-4">

--- a/app/views/voices/edit.html.erb
+++ b/app/views/voices/edit.html.erb
@@ -1,19 +1,19 @@
 <div class="container-fluid bg-dark text-white">
-  <p class="h2 py-4 d-flex justify-content-center text-center"><%= (t '.title') %></p>
-  <div class="d-flex justify-content-center">
+  <h2 class="py-5 d-flex justify-content-center text-center"><%= (t '.title') %></h2>
+  <div class="d-flex justify-content-center mb-5">
     <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-edit-page-player') %>
   </div>
-  <div class="my-4 h5 text-break text-center">
+  <div class="mb-4 h5 text-break text-center">
     <% unless @voice.user.role == "guest" %>
       <%= (t '.by') %> <%= @voice.user.name %>
     <% end %>
   </div>
-  <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
+  <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3 pb-4">
     <%= form_with model: @voice, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
       <%= f.label :description, Voice.human_attribute_name(:description) %>
       <%= f.text_field :description, class: 'form-control' %>
-      <%= f.submit (t '.update_button'), class: 'btn btn-primary d-block mx-auto rounded-pill my-3' %>
+      <%= f.submit (t '.update_button'), class: 'btn btn-primary d-block mx-auto rounded-pill my-4' %>
     <% end %>
   </div>
 </div>

--- a/app/views/voices/index.html.erb
+++ b/app/views/voices/index.html.erb
@@ -6,6 +6,7 @@
       <% else %>
         <p><%= (t '.voice_not_found_message') %></p>
       <% end %>
+      <%== pagy_nav(@pagy) %>
     </div>
   </div>
 </div>

--- a/app/views/voices/index.html.erb
+++ b/app/views/voices/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container-fluid bg-dark text-white">
   <div class="col-10 offset-1 py-5 d-flex justify-content-center text-center">
-    <div class="row">
+    <div class="row col-12">
       <% if @voices.present? %>
         <%= render @voices %>
       <% else %>

--- a/app/views/voices/index.html.erb
+++ b/app/views/voices/index.html.erb
@@ -1,0 +1,11 @@
+<div class="container-fluid bg-dark text-white">
+  <div class="col-10 offset-1 py-5 d-flex justify-content-center text-center">
+    <div class="row">
+      <% if @voices.present? %>
+        <%= render @voices %>
+      <% else %>
+        <p>まだ投稿音声がありません</p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/voices/index.html.erb
+++ b/app/views/voices/index.html.erb
@@ -4,7 +4,7 @@
       <% if @voices.present? %>
         <%= render @voices %>
       <% else %>
-        <p>まだ投稿音声がありません</p>
+        <p><%= (t '.voice_not_found_message') %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/voices/index.html.erb
+++ b/app/views/voices/index.html.erb
@@ -7,7 +7,7 @@
         <p><%= (t '.voice_not_found_message') %></p>
       <% end %>
       <div class="d-flex justify-content-center mt-3">
-        <%== pagy_bootstrap_nav(@pagy) %>
+        <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
       </div>
     </div>
   </div>

--- a/app/views/voices/index.html.erb
+++ b/app/views/voices/index.html.erb
@@ -6,7 +6,9 @@
       <% else %>
         <p><%= (t '.voice_not_found_message') %></p>
       <% end %>
-      <%== pagy_nav(@pagy) %>
+      <div class="d-flex justify-content-center mt-3">
+        <%== pagy_bootstrap_nav(@pagy) %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -9,7 +9,7 @@
       </div>
       <div class="mb-4 h5 text-break">
         <% unless @voice.user.role == "guest" %>
-          <%= (t '.by') %> <%= @voice.user.name %>
+          <%= (t 'defaults.by') %> <%= @voice.user.name %>
         <% end %>
       </div>
       <div class="py-5">

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -9,7 +9,7 @@
       </div>
       <div class="mb-4 h5 text-break">
         <% unless @voice.user.role == "guest" %>
-          <%= (t 'defaults.by') %> <%= @voice.user.name %>
+          <%= (t 'defaults.by') %><%= @voice.user.name %>
         <% end %>
       </div>
       <div class="py-5">

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -12,9 +12,11 @@
           <%= (t '.by') %> <%= @voice.user.name %>
         <% end %>
       </div>
-      <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-show-page-player') %>
+      <div class="py-5">
+        <%= audio_tag("#{@voice.growl_voice.url}", controls: true, id: 'js-show-page-player') %>
+      </div>
       <% if logged_in? && @voice.user_id == current_user.id %>
-        <div class="m-3 d-flex justify-content-center">
+        <div class="pb-5 d-flex justify-content-center">
           <div class="mx-3">
             <%= link_to edit_voice_path(@voice) do %>
               <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i> <%= (t '.to_edit') %></button>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -235,7 +235,7 @@ require 'pagy/extras/bootstrap'
 # I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
 # than the default pagy internal i18n (see above)
 # See https://ddnexus.github.io/pagy/extras/i18n
-# require 'pagy/extras/i18n'
+require 'pagy/extras/i18n'
 
 # Default i18n key
 # Pagy::DEFAULT[:i18n_key] = 'pagy.item_name'   # default

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -4,19 +4,16 @@
 # Customize only what you really need and notice that the core Pagy works also without any of the following lines.
 # Should you just cherry pick part of this file, please maintain the require-order of the extras
 
-
 # Pagy DEFAULT Variables
 # See https://ddnexus.github.io/pagy/api/pagy#variables
 # All the Pagy::DEFAULT are set for all the Pagy instances but can be overridden per instance by just passing them to
 # Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
 
-
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
 # Pagy::DEFAULT[:page]   = 1                                  # default
-Pagy::DEFAULT[:items]  = 10
+Pagy::DEFAULT[:items] = 10
 # Pagy::DEFAULT[:outset] = 0                                  # default
-
 
 # Other Variables
 # See https://ddnexus.github.io/pagy/api/pagy#other-variables
@@ -29,10 +26,8 @@ Pagy::DEFAULT[:items]  = 10
 # Pagy::DEFAULT[:i18n_key]   = 'pagy.item_name'                # default
 # Pagy::DEFAULT[:cycle]      = true                            # example
 
-
 # Extras
 # See https://ddnexus.github.io/pagy/extras
-
 
 # Backend Extras
 
@@ -117,7 +112,6 @@ Pagy::DEFAULT[:items]  = 10
 # uncomment if you are going to use Searchkick.pagy_search
 # Searchkick.extend Pagy::Searchkick
 
-
 # Frontend Extras
 
 # Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
@@ -153,7 +147,6 @@ require 'pagy/extras/bootstrap'
 # Multi size var used by the *_nav_js helpers
 # See https://ddnexus.github.io/pagy/extras/navs#steps
 # Pagy::DEFAULT[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
-
 
 # Feature Extras
 
@@ -191,7 +184,6 @@ require 'pagy/extras/bootstrap'
 # See https://ddnexus.github.io/pagy/extras/standalone
 # require 'pagy/extras/standalone'
 # Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
-
 
 # Rails
 # Enable the .js file required by the helpers that use javascript
@@ -231,7 +223,6 @@ require 'pagy/extras/bootstrap'
 #                   filepath: 'path/to/pagy-xyz.yml',
 #                   pluralize: lambda{ |count| ... } )
 
-
 # I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
 # than the default pagy internal i18n (see above)
 # See https://ddnexus.github.io/pagy/extras/i18n
@@ -239,7 +230,6 @@ require 'pagy/extras/i18n'
 
 # Default i18n key
 # Pagy::DEFAULT[:i18n_key] = 'pagy.item_name'   # default
-
 
 # When you are done setting your own default freeze it, so it will not get changed accidentally
 Pagy::DEFAULT.freeze

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (5.10.1)
+# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+
+# Pagy DEFAULT Variables
+# See https://ddnexus.github.io/pagy/api/pagy#variables
+# All the Pagy::DEFAULT are set for all the Pagy instances but can be overridden per instance by just passing them to
+# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/api/pagy#instance-variables
+# Pagy::DEFAULT[:page]   = 1                                  # default
+Pagy::DEFAULT[:items]  = 10
+# Pagy::DEFAULT[:outset] = 0                                  # default
+
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/api/pagy#other-variables
+# Pagy::DEFAULT[:size]       = [1,4,4,1]                       # default
+# Pagy::DEFAULT[:page_param] = :page                           # default
+# The :params can be also set as a lambda e.g ->(params){ params.exclude('useless').merge!('custom' => 'useful') }
+# Pagy::DEFAULT[:params]     = {}                              # default
+# Pagy::DEFAULT[:fragment]   = '#fragment'                     # example
+# Pagy::DEFAULT[:link_extra] = 'data-remote="true"'            # example
+# Pagy::DEFAULT[:i18n_key]   = 'pagy.item_name'                # default
+# Pagy::DEFAULT[:cycle]      = true                            # example
+
+
+# Extras
+# See https://ddnexus.github.io/pagy/extras
+
+
+# Backend Extras
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/extras/array
+# require 'pagy/extras/array'
+
+# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
+# See https://ddnexus.github.io/pagy/extras/calendar
+# require 'pagy/extras/calendar'
+# Default for each unit
+# Pagy::Calendar::Year::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Year::DEFAULT[:format]    = '%Y'        # strftime format
+#
+# Pagy::Calendar::Quarter::DEFAULT[:order]  = :asc        # Time direction of pagination
+# Pagy::Calendar::Quarter::DEFAULT[:format] = '%Y-Q%q'    # strftime format
+#
+# Pagy::Calendar::Month::DEFAULT[:order]    = :asc        # Time direction of pagination
+# Pagy::Calendar::Month::DEFAULT[:format]   = '%Y-%m'     # strftime format
+#
+# Pagy::Calendar::Week::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Week::DEFAULT[:format]    = '%Y-%W'     # strftime format
+#
+# Pagy::Calendar::Day::DEFAULT[:order]      = :asc        # Time direction of pagination
+# Pagy::Calendar::Day::DEFAULT[:format]     = '%Y-%m-%d'  # strftime format
+#
+# Uncomment the following lines, if you need calendar localization without using the I18n extra
+# module LocalizePagyCalendar
+#   def localize(time, opts)
+#     ::I18n.l(time, **opts)
+#   end
+# end
+# Pagy::Calendar.prepend LocalizePagyCalendar
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
+# Default :pagy_search method: change only if you use also
+# the searchkick or meilisearch extra that defines the same
+# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
+# require 'pagy/extras/elasticsearch_rails'
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::DEFAULT[:headers] = { page: 'Current-Page',
+#                            items: 'Page-Items',
+#                            count: 'Total-Count',
+#                            pages: 'Total-Pages' }     # default
+
+# Meilisearch extra: Paginate `Meilisearch` result objects
+# See https://ddnexus.github.io/pagy/extras/meilisearch
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or searchkick extra that define the same method
+# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:meilisearch_search] = :ms_search
+# require 'pagy/extras/meilisearch'
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/extras/metadata
+# you must require the shared internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/shared'
+# require 'pagy/extras/metadata'
+# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/extras/searchkick
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or meilisearch extra that defines the same
+# DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:searchkick_search] = :search
+# require 'pagy/extras/searchkick'
+# uncomment if you are going to use Searchkick.pagy_search
+# Searchkick.extend Pagy::Searchkick
+
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/extras/navs#steps
+# Pagy::DEFAULT[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+
+# Feature Extras
+
+# Gearbox extra: Automatically change the number of items per page depending on the page number
+# See https://ddnexus.github.io/pagy/extras/gearbox
+# require 'pagy/extras/gearbox'
+# set to false only if you want to make :gearbox_extra an opt-in variable
+# Pagy::DEFAULT[:gearbox_extra] = false               # default true
+# Pagy::DEFAULT[:gearbox_items] = [15, 30, 60, 100]   # default
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/extras/items
+# require 'pagy/extras/items'
+# set to false only if you want to make :items_extra an opt-in variable
+# Pagy::DEFAULT[:items_extra] = false    # default true
+# Pagy::DEFAULT[:items_param] = :items   # default
+# Pagy::DEFAULT[:max_items]   = 100      # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/extras/support
+# require 'pagy/extras/support'
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/extras/trim
+# require 'pagy/extras/trim'
+# set to false only if you want to make :trim_extra an opt-in variable
+# Pagy::DEFAULT[:trim_extra] = false # default true
+
+# Standalone extra: Use pagy in non Rack environment/gem
+# See https://ddnexus.github.io/pagy/extras/standalone
+# require 'pagy/extras/standalone'
+# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
+
+
+# Rails
+# Enable the .js file required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/extras#javascript
+
+# With the asset pipeline
+# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/api/frontend#i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'de' },
+#                 { locale: 'en' },
+#                 { locale: 'es' })
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'en' },
+#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
+#                 { locale: 'xyz',  # not built-in
+#                   filepath: 'path/to/pagy-xyz.yml',
+#                   pluralize: lambda{ |count| ... } )
+
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::DEFAULT[:i18n_key] = 'pagy.item_name'   # default
+
+
+# When you are done setting your own default freeze it, so it will not get changed accidentally
+Pagy::DEFAULT.freeze

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -122,7 +122,7 @@ Pagy::DEFAULT[:items]  = 10
 
 # Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
 # See https://ddnexus.github.io/pagy/extras/bootstrap
-# require 'pagy/extras/bootstrap'
+require 'pagy/extras/bootstrap'
 
 # Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
 # See https://ddnexus.github.io/pagy/extras/bulma

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -12,6 +12,7 @@ ja:
     privacy_policy: 'プライバシーポリシー'
     inquiry: 'お問い合わせ'
     copyright: 'Copyright © 2022. デスボイスチェンジャー'
+    by: 'By'
     message:
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新できませんでした"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -52,6 +52,8 @@ ja:
       title: '編集'
       by: 'By'
       update_button: '更新する'
+    index:
+      voice_not_found_message: 'まだ投稿音声がありません'
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -45,12 +45,10 @@ ja:
       save_as_logged_in_user: '保存してシェア画面へ'
       to_share: 'シェア画面へ'
     show:
-      by: 'By'
       to_edit: '編集'
       to_delete: '削除'
     edit:
       title: '編集'
-      by: 'By'
       update_button: '更新する'
     index:
       voice_not_found_message: 'まだ投稿音声がありません'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -12,7 +12,7 @@ ja:
     privacy_policy: 'プライバシーポリシー'
     inquiry: 'お問い合わせ'
     copyright: 'Copyright © 2022. デスボイスチェンジャー'
-    by: 'By'
+    by: 'By '
     message:
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新できませんでした"

--- a/config/locales/views/pagy-ja.yml
+++ b/config/locales/views/pagy-ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前へ"
+      next: "次へ &rsaquo;"
+      truncate: "..."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :voices, only: %i[new create show destroy edit update]
+  resources :voices
 end


### PR DESCRIPTION
## 概要
音声一覧画面を作成し、ページネーションを実装しました。
ページネーションにはgem `pagy`を使用しました。
1ページに表示される件数は10件です。
一覧画面に表示される音声は、statusがopenのものだけです。
ゲストユーザーのものとして作成された音声はstatusがclosedになるように実装しました。 a9f872b 
その他詳細ページと編集ページの細かいレイアウトの調整も行いました。 07af4a609f8989e699bcaeec43fe2f841f41c1c1 96b4934a3153be976bf8c0c3cbe16e4b101ba639 766ed09 

**参考記事**
[How to](https://ddnexus.github.io/pagy/how-to.html#gsc.tab=0)
[Rails: Pagy gemでRailsアプリを高速ページネーション（翻訳)](https://techracho.bpsinc.jp/hachi8833/2021_07_13/57481)
[[Rails] 新興のgem pagyをつかってページネーション機能を実装する](https://qiita.com/junara/items/eb85559547f87c8cb6b3)
[Railsでpagyを使ったページネーション](https://qiita.com/white0221/items/d5a0386882943131df77)
[pagyを日本語化してみる](https://qiita.com/dabpaq/items/4f89366448ad863e6e6a)

以下は`kaminari`を使用した記事ですが、ディベロッパツールで検証するとpagyで使用されているクラスとkaminariで使用されているクラスが同じ命名であったので色の変更をする際参考になりました。
[【Rails初心者】ページネーションを実装して自分好みにデザインを変える](https://qiita.com/rio_threehouse/items/313824b90a31268b0074)

close #52 

## 確認方法
1. サーバーを立ち上げ、ログインします。
2. 音声を10件以上作成します。(音声はブラウザで録音しなければならない都合上seedデータを用意していません)
3. `/voices`にアクセスします。音声が一覧表示されることを確認してください。
4. ページネーションされていることを確認してください。
5. ログアウトし、音声を作成してください。
6. `/voices`にログアウトしている状態で録音した音声は表示されていないことを確認してください。
