### PR TITLE
お題投稿ページを実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger, :light, :dark, :secondary
   include Pagy::Backend
+
+  def not_authenticated
+    redirect_to login_url, danger: t('defaults.message.please_login')
+  end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,0 +1,4 @@
+class TopicsController < ApplicationController
+  def new
+  end
+end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,4 +1,6 @@
 class TopicsController < ApplicationController
+  before_action :require_login, only: %i[new]
+
   def new
     @topic = current_user.topics.build
   end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -4,9 +4,9 @@ class TopicsController < ApplicationController
   end
 
   def create
-    topic = current_user.topics.build(topic_params)
+    @topic = current_user.topics.build(topic_params)
 
-    if topic.save
+    if @topic.save
       redirect_to root_path, dark: 'お題を作成しました'
     else
       flash.now[:danger] = 'お題作成に失敗しました'

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,4 +1,22 @@
 class TopicsController < ApplicationController
   def new
+    @topic = current_user.topics.build
+  end
+
+  def create
+    topic = current_user.topics.build(topic_params)
+
+    if topic.save
+      redirect_to root_path, dark: 'お題を作成しました'
+    else
+      flash.now[:danger] = 'お題作成に失敗しました'
+      render :new
+    end
+  end
+
+  private
+
+  def topic_params
+    params.require(:topic).permit(:body)
   end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -7,9 +7,9 @@ class TopicsController < ApplicationController
     @topic = current_user.topics.build(topic_params)
 
     if @topic.save
-      redirect_to root_path, dark: 'お題を作成しました'
+      redirect_to root_path, dark: t('defaults.message.created', item: Topic.model_name.human)
     else
-      flash.now[:danger] = 'お題作成に失敗しました'
+      flash.now[:danger] = t('defaults.message.not_created', item: Topic.model_name.human)
       render :new
     end
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,3 @@
+class Topic < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,5 +1,5 @@
 class Topic < ApplicationRecord
   belongs_to :user
 
-  validates :body, presence: true, length: { maximum: 100 }
+  validates :body, presence: true, length: { maximum: 100 }, uniqueness: true
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,3 +1,5 @@
 class Topic < ApplicationRecord
   belongs_to :user
+
+  validates :body, presence: true, length: { maximum: 100 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :voices, dependent: :destroy
+  has_many :topics, dependent: :destroy
 
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Topics#new</h1>
+<p>Find me in app/views/topics/new.html.erb</p>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -6,7 +6,7 @@
       <h5><%= (t '.description_for_topics') %></h5>
       <p><%= (t '.notice_about_post') %></p>
     </div>
-  <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3 pb-4">
+  <div class="col-10 offset-1 pb-4">
     <%= form_with model: @topic, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
       <%= f.text_field :body, class: 'form-control' %>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -1,2 +1,11 @@
-<h1>Topics#new</h1>
-<p>Find me in app/views/topics/new.html.erb</p>
+<div class="container-fluid bg-dark text-white">
+  <div class="d-flex justify-content-center">
+    <h2 class="py-5">お題投稿</h2>
+  </div>
+  <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3 pb-4">
+    <%= form_with model: @topic, local: true do |f| %>
+      <%= f.text_field :body, class: 'form-control' %>
+      <%= f.submit '投稿する', class: 'btn btn-primary d-block mx-auto rounded-pill my-4' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -1,12 +1,12 @@
 <div class="container-fluid bg-dark text-white">
   <div class="d-flex justify-content-center">
-    <h2 class="py-5">お題投稿</h2>
+    <h2 class="py-5"><%= (t '.title') %></h2>
   </div>
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3 pb-4">
     <%= form_with model: @topic, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
       <%= f.text_field :body, class: 'form-control' %>
-      <%= f.submit '投稿する', class: 'btn btn-primary d-block mx-auto rounded-pill my-4' %>
+      <%= f.submit (t '.post'), class: 'btn btn-primary d-block mx-auto rounded-pill my-4' %>
     <% end %>
   </div>
 </div>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -3,9 +3,9 @@
     <h2 class="pt-5 mb-3"><%= (t '.title') %></h2>
   </div>
   <div class="text-center mb-5">
-      <h5><%= (t '.description_for_topics') %></h5>
-      <p><%= (t '.notice_about_post') %></p>
-    </div>
+    <h5><%= (t '.description_for_topics') %></h5>
+    <p><%= (t '.notice_about_post') %></p>
+  </div>
   <div class="col-10 offset-1 pb-4">
     <%= form_with model: @topic, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -1,7 +1,11 @@
 <div class="container-fluid bg-dark text-white">
   <div class="d-flex justify-content-center">
-    <h2 class="py-5"><%= (t '.title') %></h2>
+    <h2 class="pt-5 mb-3"><%= (t '.title') %></h2>
   </div>
+  <div class="text-center mb-5">
+      <h5><%= (t '.description_for_topics') %></h5>
+      <p><%= (t '.notice_about_post') %></p>
+    </div>
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3 pb-4">
     <%= form_with model: @topic, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -4,6 +4,7 @@
   </div>
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3 pb-4">
     <%= form_with model: @topic, local: true do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
       <%= f.text_field :body, class: 'form-control' %>
       <%= f.submit '投稿する', class: 'btn btn-primary d-block mx-auto rounded-pill my-4' %>
     <% end %>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @topic, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
       <%= f.text_field :body, class: 'form-control' %>
-      <%= f.submit (t '.post'), class: 'btn btn-primary d-block mx-auto rounded-pill my-4' %>
+      <%= f.submit (t '.post'), class: 'btn btn-primary d-block mx-auto rounded-pill my-4', data: { confirm: (t '.post_confirmation') } %>
     <% end %>
   </div>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       user: 'ユーザー'
       voice: '音声'
+      topic: 'お題'
     attributes:
       user:
         email: 'メールアドレス'
@@ -14,6 +15,8 @@ ja:
         growl_voice: 'デスボ'
         description: '内容'
         status: '公開状況'
+      topic:
+        body: 'お題'
 
   enums:
     user:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,6 +20,7 @@ ja:
       not_updated: "%{item}を更新できませんでした"
       deleted: "%{item}を削除しました"
       delete_confirm: '本当に削除しますか？'
+      please_login: 'ログインしてください'
   users:
     new:
       title: 'ユーザー登録'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -14,6 +14,8 @@ ja:
     copyright: 'Copyright © 2022. デスボイスチェンジャー'
     by: 'By '
     message:
+      created: "%{item}を作成しました"
+      not_created: "%{item}を作成できませんでした"
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新できませんでした"
       deleted: "%{item}を削除しました"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -60,6 +60,8 @@ ja:
       title: 'お題投稿'
       post: '投稿する'
       post_confirmation: "一度投稿されたお題は編集・削除ができません。\r\n投稿しますか？"
+      description_for_topics: 'デスボイスで言ったら面白そうな言葉や、こんな時デスボイスでどう返す？といったお題を投稿できます。'
+      notice_about_post: '※お題は投稿された後では編集・削除ができません。よく確認してからご投稿ください。'
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -54,6 +54,10 @@ ja:
       update_button: '更新する'
     index:
       voice_not_found_message: 'まだ投稿音声がありません'
+  topics:
+    new:
+      title: 'お題投稿'
+      post: '投稿する'
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -59,6 +59,7 @@ ja:
     new:
       title: 'お題投稿'
       post: '投稿する'
+      post_confirmation: "一度投稿されたお題は編集・削除ができません。\r\n投稿しますか？"
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[new create]
   resources :voices
-  resources :topics, only: %i[new]
+  resources :topics, only: %i[new create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[new create]
   resources :voices
+  resources :topics, only: %i[new]
 end

--- a/db/migrate/20220706123021_create_topics.rb
+++ b/db/migrate/20220706123021_create_topics.rb
@@ -1,0 +1,10 @@
+class CreateTopics < ActiveRecord::Migration[6.1]
+  def change
+    create_table :topics, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.string :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220706154321_change_column_not_null_on_topics.rb
+++ b/db/migrate/20220706154321_change_column_not_null_on_topics.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNotNullOnTopics < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :topics, :body, false
+  end
+end

--- a/db/migrate/20220706155041_add_index_body_to_topics.rb
+++ b/db/migrate/20220706155041_add_index_body_to_topics.rb
@@ -1,0 +1,5 @@
+class AddIndexBodyToTopics < ActiveRecord::Migration[6.1]
+  def change
+    add_index :topics, :body, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_25_073852) do
+ActiveRecord::Schema.define(version: 2022_07_06_123021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "topics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.string "body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_topics_on_user_id"
+  end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", null: false
@@ -37,5 +45,6 @@ ActiveRecord::Schema.define(version: 2022_06_25_073852) do
     t.index ["user_id"], name: "index_voices_on_user_id"
   end
 
+  add_foreign_key "topics", "users"
   add_foreign_key "voices", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_06_154321) do
+ActiveRecord::Schema.define(version: 2022_07_06_155041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2022_07_06_154321) do
     t.string "body", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["body"], name: "index_topics_on_body", unique: true
     t.index ["user_id"], name: "index_topics_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_06_123021) do
+ActiveRecord::Schema.define(version: 2022_07_06_154321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2022_07_06_123021) do
 
   create_table "topics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
-    t.string "body"
+    t.string "body", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_topics_on_user_id"

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :topic do
+    user { nil }
+    body { "MyString" }
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Topic, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/topics_spec.rb
+++ b/spec/requests/topics_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Topics", type: :request do
+  describe "GET /new" do
+    it "returns http success" do
+      get "/topics/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## 概要
お題投稿ページを作成しました。
お題はログインユーザーのみ投稿可能にしています。
同じ文言のお題は投稿できないようにしました。

close #67

## 確認方法
1. 新たにテーブルを作成したので、`rails db:migrate`を実行後サーバーを起動してください。
2. ログインしていない状態で`topics/new`へアクセスするとログインページへ遷移することを確認してください。
3. ログイン後`topics/new`にアクセスできることを確認してください。
4. お題が投稿できること、投稿完了後トップページへ遷移しフラッシュメッセージが表示されることを確認してください。
5. 何も入力せずに投稿ボタンを押すと投稿が失敗し、エラーメッセージとフラッシュメッセージが表示されることを確認してください。
6. 重複した内容のお題は投稿できないことを確認してください。

## 影響範囲
migrationファイルを作成し、DBに新たにテーブルを作成しています。

## コメント
topicsテーブルには外部キー制約としてuser_idを設けており、もしユーザーが退会すれば、定義したアソシエーションの`dependent: :destroy`に従ってお題とその回答もユーザーと共に削除されることになります。
他のユーザーの回答まで消えてしまうことにはなりますが、退会したいユーザーにとっては自分に関係した情報が残り続けるのは嫌であろうことを鑑みてこの方法を選択しました。
DB設計的にも物理削除が望ましいと考えこの実装にしています。
この設計にした際に検討したことは以下にまとめています。
[Topicsテーブルについて](https://ripe-kayak-b03.notion.site/Topics-ca5cc156d1914a9ea550880742a00242)
退会したユーザーが作成していたお題も残してほしいという要望があった際にはお題のみ残す方法も検討します。

お題の入力フィールドはtext_areaにして改行もできるようにしたほうがいいかもしれません。必要があればIssueを作成し対応します。

お題に関する説明や注意点を直にページに書くことで対応しましたが、モーダルにしたり文言やデザインを変更したほうがいいかもしれません。こちらも必要があれば別Issueで対応します。