### PR TITLE
回答録音機能を作成

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,4 +1,6 @@
 class AnswersController < ApplicationController
+  before_action :require_login, only: %i[new]
+
   def new
     @topic = Topic.find(params[:topic_id])
   end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -10,7 +10,7 @@ class AnswersController < ApplicationController
     if answer.save
       render json: { url: root_url }
     else
-      render json: { url: new_answer_path }
+      render json: { url: new_topic_answer_path(topic) }
     end
   end
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,0 +1,22 @@
+class AnswersController < ApplicationController
+  def new
+    @topic = Topic.find(params[:topic_id])
+  end
+
+  def create
+    topic = Topic.find(params[:topic_id])
+    answer = current_user.answers.build(answer_params.merge(topic_id: topic.id))
+
+    if answer.save
+      render json: { url: root_url }
+    else
+      render json: { url: new_answer_path }
+    end
+  end
+
+  private
+
+  def answer_params
+    params.permit(:growl_voice, :description)
+  end
+end

--- a/app/javascript/packs/recording_answers.js
+++ b/app/javascript/packs/recording_answers.js
@@ -1,0 +1,273 @@
+import * as Tone from 'tone';
+import axios from 'axios';
+axios.defaults.headers['X-Requested-With'] = 'XMLHttpRequest';
+axios.defaults.headers['X-CSRF-TOKEN'] = document.getElementsByName('csrf-token')[0].getAttribute('content');
+
+const jsPermitionButton = document.getElementById('js-mic-permition-button');
+const jsStartRecordingButton = document.getElementById('js-recording-start-button');
+const jsStopRecordingButton = document.getElementById('js-recording-stop-button');
+const jsReplayButton = document.getElementById('js-replay-button');
+const jsStopReplayButton = document.getElementById('js-stop-replay-button');
+const jsPlayer = document.getElementById('js-player');
+const jsDownLoadLink = document.getElementById('js-download-link');
+const jsRecordingState = document.getElementById('js-recording-state');
+const jsResetButton = document.getElementById('js-reset-button');
+const jsAnswerSaveButton = document.getElementById('js-answer-save-button');
+
+let audioContext = null;
+let stream = null;
+let bufferSize = 1024;
+let audioSampleRate = null;
+let scriptProcessor = null;
+let audioData = [];
+let timeout = null;
+let recordedBlobUrl = null;
+
+function onAudioProcess(e) {
+  let input = e.inputBuffer.getChannelData(0);
+  let bufferData = new Float32Array(bufferSize);
+  for (let i = 0; i < bufferSize; i++) {
+    bufferData[i] = input[i];
+  }
+  audioData.push(bufferData);
+} 
+
+function exportWAV(audioData) {
+  let encodeWAV = function(samples, sampleRate) {
+    let buffer = new ArrayBuffer(44 + samples.length * 2);
+    let view = new DataView(buffer);
+
+    let writeString = function(view, offset, string) {
+      for (let i = 0; i < string.length; i++) {
+        view.setUint8(offset + i, string.charCodeAt(i));
+      }
+    };
+
+    let floatTo16BitPCM = function(output, offset, input) {
+      for (let i = 0; i < input.length; i++, offset += 2) {
+        let s = Math.max(-1, Math.min(1, input[i]));
+        output.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7FFF, true);
+      }
+    };
+
+    writeString(view, 0, 'RIFF');
+    view.setUint32(4, 32 + samples.length * 2, true);
+    writeString(view, 8, 'WAVE');
+    writeString(view, 12, 'fmt ');
+    view.setUint32(16, 16, true);
+    view.setUint16(20, 1, true);
+    view.setUint16(22, 1, true);
+    view.setUint32(24, sampleRate, true);
+    view.setUint32(28, sampleRate * 2, true);
+    view.setUint16(32, 2, true);
+    view.setUint16(34, 16, true);
+    writeString(view, 36, 'data');
+    view.setUint32(40, samples.length * 2, true);
+    floatTo16BitPCM(view, 44, samples);
+    return view;
+  };
+
+  let mergeBuffers = function(audioData) {
+    let sampleLength = 0;
+    for (let i = 0; i < audioData.length; i++) {
+      sampleLength += audioData[i].length;
+    }
+    let samples = new Float32Array(sampleLength);
+    let sampleIdx = 0;
+    for (let i = 0; i < audioData.length; i++) {
+      for (let j = 0; j < audioData[i].length; j++) {
+        samples[sampleIdx] = audioData[i][j];
+        sampleIdx++;
+      }
+    }
+    return samples;
+  };
+
+  let dataview = encodeWAV(mergeBuffers(audioData), audioSampleRate);
+  let audioBlob = new Blob([dataview], {type: 'audio/wav'});
+  recordedBlobUrl = window.URL.createObjectURL(audioBlob);
+  console.log(dataview);
+
+  let myURL = window.URL || window.webkitURL;
+  let url = myURL.createObjectURL(audioBlob);
+  jsDownLoadLink.href = url;
+}
+
+function saveAudio() {
+  exportWAV(audioData);
+  jsDownLoadLink.downloard = 'voice.wav';
+  audioContext.close().then(function() {
+  });
+}
+
+jsPermitionButton.onclick = function() {
+  jsPlayer.src = '';
+  if(!stream) {
+    navigator.mediaDevices.getUserMedia({
+      video: false,
+      audio: {
+        echoCancellation: true,
+        echoCancellationType: 'system',
+        noiseSuppression: false
+      }
+    })
+      .then(function(audio) {
+        jsPermitionButton.classList.add('d-none');
+        jsStartRecordingButton.classList.remove('d-none');
+
+        stream = audio;
+        console.log('録音可能です');
+        return stream;
+      })
+      .catch(function(error) {
+        console.error('mediaDevide.getUserMedia() error:', error);
+        return;
+      });
+  }
+
+  jsPermitionButton.disabled = true;
+  jsStartRecordingButton.disabled = false;
+  jsStopRecordingButton.disabled = true;
+  jsReplayButton.disabled = true;
+  jsStopReplayButton.disabled = true;
+};
+
+jsStartRecordingButton.onclick = function() {
+  jsPlayer.src = '';
+
+  jsStartRecordingButton.disabled = true;
+  jsStopRecordingButton.disabled = false;
+  jsReplayButton.disabled = true;
+  jsStopReplayButton.disabled = true;
+
+  jsStartRecordingButton.classList.add('d-none');
+  jsStopRecordingButton.classList.remove('d-none');
+  jsRecordingState.classList.remove('d-none');
+
+  const micAudio = new Tone.UserMedia();
+  micAudio.open();
+
+  micAudio.open().then(() => {
+    audioData = [];
+    audioContext = new AudioContext();
+    audioSampleRate = audioContext.sampleRate;
+    scriptProcessor = audioContext.createScriptProcessor(bufferSize, 2, 2);
+
+    const distortionAmount = 5;
+    const pitch = -16;
+    const vibratoFrequency = 40;
+    const vibratoDepth = 0.1;
+    const threshold = -50;
+    const ratio = 4;
+    const tremoloFrequency = 500;
+    const tremoloDepth = 1;
+    const lowLevel = 40;
+    const midLevel = -20;
+    const highLevel = 55;
+
+    const distortion = new Tone.Distortion(distortionAmount);
+    const pitchshift = new Tone.PitchShift(pitch);
+    const vibrato = new Tone.Vibrato(vibratoFrequency, vibratoDepth);
+    const compressor = new Tone.Compressor(threshold, ratio);
+    const tremolo = new Tone.Tremolo(tremoloFrequency, tremoloDepth);
+    const eq = new Tone.EQ3(lowLevel, midLevel, highLevel);
+    const convolver = new Tone.Convolver('../../../../1960-G12M25-SM57-Cone-0_5in.wav');
+    const effectedStreamDestination = Tone.context.createMediaStreamDestination();
+    micAudio.chain(pitchshift, tremolo, vibrato, distortion, eq, convolver, compressor, effectedStreamDestination);
+    
+    const effectedStream = effectedStreamDestination.stream;
+    const effectedStreamSource = audioContext.createMediaStreamSource(effectedStream);
+    effectedStreamSource.connect(scriptProcessor);
+    
+    scriptProcessor.onaudioprocess = onAudioProcess;
+    scriptProcessor.connect(audioContext.destination);
+
+    timeout = setTimeout(() => {
+      jsStopRecordingButton.click();
+    }, 30000);
+  
+    jsStopRecordingButton.addEventListener('click', () => {
+      clearTimeout(timeout);
+      console.log('録音停止しました');
+    });
+  }).catch(e => {
+    console.log('音声を加工・録音するプロセスに問題があります');
+    console.log(e);
+  });
+};
+
+jsStopRecordingButton.onclick = function() {
+  jsStopRecordingButton.classList.add('d-none');
+  jsReplayButton.classList.remove('d-none');
+  jsRecordingState.classList.add('d-none');
+  jsResetButton.classList.remove('d-none');
+  jsAnswerSaveButton.classList.remove('d-none');
+  
+  saveAudio();
+  jsPlayer.src = recordedBlobUrl;
+
+  jsStartRecordingButton.disabled = false;
+  jsStopRecordingButton.disabled = true;
+  jsReplayButton.disabled = false;
+};
+
+jsReplayButton.onclick = function() {
+  jsPlayer.play();
+};
+
+jsPlayer.onplay = function() {
+  jsReplayButton.classList.add('d-none');
+  jsStopReplayButton.classList.remove('d-none');
+
+  jsReplayButton.disabled = true;
+  jsStopReplayButton.disabled = false;
+};
+
+jsPlayer.onpause = function() {
+  jsReplayButton.classList.remove('d-none');
+  jsStopReplayButton.classList.add('d-none');
+
+  jsReplayButton.disabled = false;
+  jsStopReplayButton.disabled = true;
+};
+
+jsStopReplayButton.onclick = function() {
+  jsPlayer.pause();
+};
+
+jsResetButton.onclick = function() {
+  jsPlayer.src = '';
+
+  jsStartRecordingButton.classList.remove('d-none');
+  jsResetButton.classList.add('d-none');
+  jsReplayButton.classList.add('d-none');
+  jsStopReplayButton.classList.add('d-none');
+  jsAnswerSaveButton.classList.add('d-none');
+
+  jsStartRecordingButton.disabled = false;
+  jsReplayButton.disabled = true;
+};
+
+jsAnswerSaveButton.onclick = function() {
+  jsAnswerSaveButton.disabled = true;
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', jsDownLoadLink.href, true);
+  xhr.responseType = 'blob';
+  xhr.send();
+  xhr.onload = function() {
+    var myBlob = this.response;
+    let formData = new FormData();
+    formData.append('description', document.getElementById('description-form').value);
+    formData.append('growl_voice', myBlob, 'answer_growl_voice.wav');
+    axios.post(document.getElementById('answer-form').action, formData, {
+      headers: {
+        'content-type': 'multipart/form-data',
+      }
+    }).then(response => {
+      let data = response.data;
+      window.location.href = data.url;
+    }).catch(error => {
+      console.log(error.response);
+    });
+  };
+};

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,4 @@
+class Answer < ApplicationRecord
+  belongs_to :user
+  belongs_to :topic
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,6 +1,7 @@
 class Answer < ApplicationRecord
   belongs_to :user
   belongs_to :topic
+  mount_uploader :growl_voice, GrowlVoiceUploader
 
   validates :growl_voice, presence: true
   validates :description, presence: true, length: { maximum: 30 }

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,4 +1,7 @@
 class Answer < ApplicationRecord
   belongs_to :user
   belongs_to :topic
+
+  validates :growl_voice, presence: true
+  validates :description, presence: true, length: { maximum: 30 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :voices, dependent: :destroy
   has_many :topics, dependent: :destroy
+  has_many :answers, dependent: :destroy
 
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/voice.rb
+++ b/app/models/voice.rb
@@ -2,6 +2,7 @@ class Voice < ApplicationRecord
   belongs_to :user
   mount_uploader :growl_voice, GrowlVoiceUploader
 
+  validates :growl_voice, presence: true
   validates :description, presence: true, length: { maximum: 30 }
 
   enum status: { open: 0, closed: 1 }

--- a/app/uploaders/growl_voice_uploader.rb
+++ b/app/uploaders/growl_voice_uploader.rb
@@ -38,9 +38,9 @@ class GrowlVoiceUploader < CarrierWave::Uploader::Base
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_allowlist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_white_list
+    %w[wav ogg oga mp3 webm]
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -34,7 +34,7 @@
     <% end %>
   </div>
   <div class="pb-5">
-      <button id="js-answer-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none">投稿する</button>
+      <button id="js-answer-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none"><%= (t '.post') %></button>
   </div>
 </div>
 

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -14,16 +14,16 @@
     <audio id="js-player" controls></audio>
     <a id="js-download-link" type="hidden"></a>
   </div>
-  <div id="js-recording-state" class="text-center d-none">Now Recording ...</div>
+  <div id="js-recording-state" class="text-center d-none"><%= (t 'defaults.now_recording') %></div>
   <div class="d-flex justify-content-center py-2">
-    <button id="js-mic-permition-button" class="btn btn-primary rounded-pill">マイク許可</button>
-    <button id="js-recording-start-button" class="btn btn-primary rounded-pill d-none">録音開始</button>
-    <button id="js-recording-stop-button" class="btn btn-primary rounded-pill d-none">録音停止</button>
-    <button id="js-replay-button" class="btn btn-primary rounded-pill d-none">音声再生</button>
-    <button id="js-stop-replay-button" class="btn btn-primary rounded-pill d-none">音声停止</button>
+    <button id="js-mic-permition-button" class="btn btn-primary rounded-pill"><%= (t 'defaults.mic_permition') %></button>
+    <button id="js-recording-start-button" class="btn btn-primary rounded-pill d-none"><%= (t 'defaults.recording_start') %></button>
+    <button id="js-recording-stop-button" class="btn btn-primary rounded-pill d-none"><%= (t 'defaults.recording_stop') %></button>
+    <button id="js-replay-button" class="btn btn-primary rounded-pill d-none"><%= (t 'defaults.replay') %></button>
+    <button id="js-stop-replay-button" class="btn btn-primary rounded-pill d-none"><%= (t 'defaults.stop_replay') %></button>
   </div>
   <div class="d-flex justify-content-center py-2">
-    <button id="js-reset-button" class="btn btn-primary rounded-pill d-none">録り直す</button>
+    <button id="js-reset-button" class="btn btn-primary rounded-pill d-none"><%= (t 'defaults.reset') %></button>
   </div>
 
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -29,7 +29,7 @@
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
     <%= form_with url: topic_answers_path(@topic), id: 'answer-form', local: true do |f| %>
       <%= f.hidden_field :growl_voice %>
-      <%= f.label :description, '内容' %>
+      <%= f.label :description, Answer.human_attribute_name(:description) %>
       <%= f.text_field :description, class: 'form-control', id: 'description-form' %>
     <% end %>
   </div>

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid bg-dark text-white">
-  <h1 class="text-center py-4">お題に回答！</h1>
+  <h1 class="text-center py-4"><%= (t '.title') %></h1>
   <div class="col-10 offset-1 pb-5 d-flex justify-content-center text-center">
     <div class="row col-12">
       <div class="card bg-gray-color text-white border-dark p-3">

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -1,0 +1,41 @@
+<div class="container-fluid bg-dark text-white">
+  <h1 class="text-center py-4">お題に回答！</h1>
+  <div class="col-10 offset-1 pb-5 d-flex justify-content-center text-center">
+    <div class="row col-12">
+      <div class="card bg-gray-color text-white border-dark p-3">
+        <div class="card-body">
+          <h4 class="card-title"><%= @topic.body %></h4>
+          <p class="card-text"><%= (t 'defaults.topic_giver') %><%= @topic.user.name %></p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="d-flex justify-content-center py-4">
+    <audio id="js-player" controls></audio>
+    <a id="js-download-link" type="hidden"></a>
+  </div>
+  <div id="js-recording-state" class="text-center d-none">Now Recording ...</div>
+  <div class="d-flex justify-content-center py-2">
+    <button id="js-mic-permition-button" class="btn btn-primary rounded-pill">マイク許可</button>
+    <button id="js-recording-start-button" class="btn btn-primary rounded-pill d-none">録音開始</button>
+    <button id="js-recording-stop-button" class="btn btn-primary rounded-pill d-none">録音停止</button>
+    <button id="js-replay-button" class="btn btn-primary rounded-pill d-none">音声再生</button>
+    <button id="js-stop-replay-button" class="btn btn-primary rounded-pill d-none">音声停止</button>
+  </div>
+  <div class="d-flex justify-content-center py-2">
+    <button id="js-reset-button" class="btn btn-primary rounded-pill d-none">録り直す</button>
+  </div>
+
+  <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
+    <%= form_with url: topic_answers_path(@topic), id: 'answer-form', local: true do |f| %>
+      <%= f.hidden_field :growl_voice %>
+      <%= f.label :description, '内容' %>
+      <%= f.text_field :description, class: 'form-control', id: 'description-form' %>
+    <% end %>
+  </div>
+  <div class="pb-5">
+      <button id="js-answer-save-button" class="btn btn-primary d-block mx-auto rounded-pill text-black my-3 d-none">投稿する</button>
+  </div>
+</div>
+
+<%= javascript_pack_tag 'recording_answers' %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -18,7 +18,7 @@
             <% end %>
           </li>
           <li class="nav-item">
-            <%= link_to '#', class: 'nav-link' do %>
+            <%= link_to topics_path, class: 'nav-link' do %>
               <i class="fas fa-list-ul"></i><%= (t 'defaults.topics_list') %>
             <% end %>
           </li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,7 +18,7 @@
             <% end %>
           </li>
           <li class="nav-item">
-            <%= link_to '#', class: 'nav-link' do %>
+            <%= link_to topics_path, class: 'nav-link' do %>
               <i class="fas fa-list-ul"></i><%= (t 'defaults.topics_list') %>
             <% end %>
           </li>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -14,7 +14,9 @@
         <% end %>
       </div>
       <div class="column my-2 mx-3">
-        <button type="button" class="btn btn-dark rounded-pill"><%= (t '.to_topics_list') %></button>
+        <%= link_to topics_path do %>
+          <button type="button" class="btn btn-dark rounded-pill"><%= (t '.to_topics_list') %></button>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -9,7 +9,9 @@
         </div>
       </div>
       <div class="py-3">
-        <%= link_to (t '.to_new_topic_answer'), new_topic_answer_path(@topic), class: 'btn btn-primary justify-content-center rounded-pill my-4' %>
+        <% if logged_in? %>
+          <%= link_to (t '.to_new_topic_answer'), new_topic_answer_path(@topic), class: 'btn btn-primary justify-content-center rounded-pill my-4' %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -8,6 +8,9 @@
           <p class="card-text"><%= (t 'defaults.topic_giver') %><%= @topic.user.name %></p>
         </div>
       </div>
+      <div class="py-3">
+        <%= link_to 'お題に回答', new_topic_answer_path(@topic), class: 'btn btn-primary justify-content-center rounded-pill my-4' %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -9,7 +9,7 @@
         </div>
       </div>
       <div class="py-3">
-        <%= link_to 'お題に回答', new_topic_answer_path(@topic), class: 'btn btn-primary justify-content-center rounded-pill my-4' %>
+        <%= link_to (t '.to_new_topic_answer'), new_topic_answer_path(@topic), class: 'btn btn-primary justify-content-center rounded-pill my-4' %>
       </div>
     </div>
   </div>

--- a/app/views/voices/new.html.erb
+++ b/app/views/voices/new.html.erb
@@ -17,7 +17,7 @@
   </div>
 
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
-    <%= form_with model: @voice, local: true do |f| %>
+    <%= form_with url: voices_path, local: true do |f| %>
       <%= f.hidden_field :growl_voice %>
       <%= f.label :description, Voice.human_attribute_name(:description) %>
       <%= f.text_field :description, class: 'form-control', id: 'description-form' %>

--- a/app/views/voices/new.html.erb
+++ b/app/views/voices/new.html.erb
@@ -4,16 +4,16 @@
     <audio id="js-player" controls></audio>
     <a id="js-download-link" type="hidden"></a>
   </div>
-  <div id="js-recording-state" class="text-center d-none"><%= (t '.now_recording') %></div>
+  <div id="js-recording-state" class="text-center d-none"><%= (t 'defaults.now_recording') %></div>
   <div class="d-flex justify-content-center py-2">
-    <button id="js-mic-permition-button" class="btn btn-primary rounded-pill"><%= (t '.mic_permition') %></button>
-    <button id="js-recording-start-button" class="btn btn-primary rounded-pill d-none"><%= (t '.recording_start') %></button>
-    <button id="js-recording-stop-button" class="btn btn-primary rounded-pill d-none"><%= (t '.recording_stop') %></button>
-    <button id="js-replay-button" class="btn btn-primary rounded-pill d-none"><%= (t '.replay') %></button>
-    <button id="js-stop-replay-button" class="btn btn-primary rounded-pill d-none"><%= (t '.stop_replay') %></button>
+    <button id="js-mic-permition-button" class="btn btn-primary rounded-pill"><%= (t 'defaults.mic_permition') %></button>
+    <button id="js-recording-start-button" class="btn btn-primary rounded-pill d-none"><%= (t 'defaults.recording_start') %></button>
+    <button id="js-recording-stop-button" class="btn btn-primary rounded-pill d-none"><%= (t 'defaults.recording_stop') %></button>
+    <button id="js-replay-button" class="btn btn-primary rounded-pill d-none"><%= (t 'defaults.replay') %></button>
+    <button id="js-stop-replay-button" class="btn btn-primary rounded-pill d-none"><%= (t 'defaults.stop_replay') %></button>
   </div>
   <div class="d-flex justify-content-center py-2">
-    <button id="js-reset-button" class="btn btn-primary rounded-pill d-none"><%= (t '.reset') %></button>
+    <button id="js-reset-button" class="btn btn-primary rounded-pill d-none"><%= (t 'defaults.reset') %></button>
   </div>
 
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -4,6 +4,7 @@ ja:
       user: 'ユーザー'
       voice: '音声'
       topic: 'お題'
+      answer: '回答'
     attributes:
       user:
         email: 'メールアドレス'
@@ -17,6 +18,9 @@ ja:
         status: '公開状況'
       topic:
         body: 'お題'
+      answer:
+        growl_voice: '回答のデスボ'
+        description: '内容'
 
   enums:
     user:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -66,6 +66,8 @@ ja:
     index:
       title: '〜お題一覧〜'
       topic_not_found_message: 'まだお題は投稿されていません'
+    show:
+      to_new_topic_answer: 'お題に回答'
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -71,6 +71,7 @@ ja:
   answers:
     new:
       title: 'お題に回答！'
+      post: '投稿する'
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -12,6 +12,13 @@ ja:
     privacy_policy: 'プライバシーポリシー'
     inquiry: 'お問い合わせ'
     copyright: 'Copyright © 2022. デスボイスチェンジャー'
+    now_recording: 'Now Recording ...'
+    mic_permition: 'マイク許可'
+    recording_start: '録音開始'
+    recording_stop: '録音停止'
+    replay: '録音再生'
+    stop_replay: '再生停止'
+    reset: '取り直す'
     by: 'By '
     topic_giver: '出題者 '
     message:
@@ -39,13 +46,6 @@ ja:
   voices:
     new:
       title: '録音・加工する'
-      now_recording: 'Now Recording ...'
-      mic_permition: 'マイク許可'
-      recording_start: '録音開始'
-      recording_stop: '録音停止'
-      replay: '録音再生'
-      stop_replay: '再生停止'
-      reset: '取り直す'
       save_as_logged_in_user: '保存してシェア画面へ'
       to_share: 'シェア画面へ'
     show:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -68,6 +68,9 @@ ja:
       topic_not_found_message: 'まだお題は投稿されていません'
     show:
       to_new_topic_answer: 'お題に回答'
+  answers:
+    new:
+      title: 'お題に回答！'
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[new create]
   resources :voices
-  resources :topics, only: %i[new create index show]
-  resources :answers, only: %i[new create]
+  resources :topics, only: %i[new create index show] do
+    resources :answers, only: %i[new create]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   resources :voices
   resources :topics, only: %i[new create index show]
+  resources :answers, only: %i[new create]
 end

--- a/db/migrate/20220707075607_create_answers.rb
+++ b/db/migrate/20220707075607_create_answers.rb
@@ -1,0 +1,12 @@
+class CreateAnswers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :answers, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.references :topic, null: false, foreign_key: true, type: :uuid
+      t.string :growl_voice, null: false
+      t.string :description, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_06_155041) do
+ActiveRecord::Schema.define(version: 2022_07_07_075607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "topic_id", null: false
+    t.string "growl_voice", null: false
+    t.string "description", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["topic_id"], name: "index_answers_on_topic_id"
+    t.index ["user_id"], name: "index_answers_on_user_id"
+  end
 
   create_table "topics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
@@ -46,6 +57,8 @@ ActiveRecord::Schema.define(version: 2022_07_06_155041) do
     t.index ["user_id"], name: "index_voices_on_user_id"
   end
 
+  add_foreign_key "answers", "topics"
+  add_foreign_key "answers", "users"
   add_foreign_key "topics", "users"
   add_foreign_key "voices", "users"
 end

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :answer do
+    user { nil }
+    topic { nil }
+    growl_voice { "MyString" }
+    description { "MyString" }
+  end
+end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Answer, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/answers_spec.rb
+++ b/spec/requests/answers_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Answers", type: :request do
+  describe "GET /new" do
+    it "returns http success" do
+      get "/answers/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## 概要
回答録音機能を作成しました。
各お題に紐づくかたちで投稿できます。
ログインユーザーのみ投稿できるようにしています。
その他雑多なこれまでの取りこぼしにも対応しました。
- Voiceモデルのバリデーション 5a8850f 
- CarrierWaveのアップロード可能なファイルの設定 3a3f412 
- トップページとヘッダーのお題一覧へのリンクの設定 c3819d7 3795636 

close #70 

## 確認方法
1. テーブルを新たに作成したので、`rails db:migrate`実行後サーバーを起動してください。
2. ログインせずにお題詳細へアクセスし、お題に回答するボタンが表示されていないことを確認してください。
3. ログインせずに`/topics/:topic_id/answers/new`へアクセスすると、ログイン画面へ遷移することを確認してください。
4. ログイン後はお題詳細にボタンが表示されることと、`/topics/:topic_id/answers/new`へアクセスできることを確認してください。
5. 回答録音が正常にできることを確認してください。
6. 録音後内容を入力し投稿するボタンを押すと、保存が完了しトップページに遷移することを確認してください。
7. 録音後内容を入力せず投稿するボタンを押すと、保存に失敗し回答録音ページが再度リクエストされることを確認してください。

## 影響範囲
新たにDBにテーブルを作成しました。

## コメント
ルーティングはshallowオプションを使用せず、topicsのルーティングにネストして実装しています。
これは回答編集ページにもお題を表示させたい場合に都合が良いからです。shallowの場合では回答編集ページにもお題を表示させるにはクエリパラメーターにお題のidを含めなくてはいけなくなるためです。

回答録音ページで使用しているJSファイル(`recording_answers.js`)は`recording.js`との共通部分が多く、リファクタリングの対象です。別Issueを立て対応します。このような実装にした理由は以下のNotionにまとめています。

回答のフラッシュメッセージと保存失敗時のエラーメッセージの表示に関しては、音声録音ページと全く事情が同じです。
現在対策を考えています。

実装時に検討したことは以下にまとめています。
[回答録音ページ(Answers#new)実装時に詰まった箇所](https://ripe-kayak-b03.notion.site/Answers-new-9dce10e3b3bd4d08a438db83fc4af6b6)