### PR TITLE
回答詳細ページを作成

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -15,7 +15,7 @@ class AnswersController < ApplicationController
     answer = current_user.answers.build(answer_params.merge(topic_id: topic.id))
 
     if answer.save
-      render json: { url: root_url }
+      render json: { url: topic_answer_path(topic, answer) }
     else
       render json: { url: new_topic_answer_path(topic) }
     end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -12,7 +12,7 @@ class AnswersController < ApplicationController
 
   def create
     topic = Topic.find(params[:topic_id])
-    answer = current_user.answers.build(answer_params.merge(topic_id: topic.id))
+    answer = current_user.answers.build(answer_params)
 
     if answer.save
       render json: { url: topic_answer_path(topic, answer) }
@@ -24,6 +24,6 @@ class AnswersController < ApplicationController
   private
 
   def answer_params
-    params.permit(:growl_voice, :description)
+    params.permit(:growl_voice, :description, :topic_id)
   end
 end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -5,6 +5,11 @@ class AnswersController < ApplicationController
     @topic = Topic.find(params[:topic_id])
   end
 
+  def show
+    @topic = Topic.find(params[:topic_id])
+    @answer = Answer.find(params[:id])
+  end
+
   def create
     topic = Topic.find(params[:topic_id])
     answer = current_user.answers.build(answer_params.merge(topic_id: topic.id))

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid bg-dark text-white">
-  <h2 class="pt-4 text-center">お題</h2>
+  <h2 class="pt-4 text-center"><%= Topic.model_name.human %></h2>
   <div class="col-10 offset-1 p-2 d-flex justify-content-center text-center">
     <div class="row col-12">
       <div class="card bg-gray-color text-white border-dark p-3">
@@ -29,12 +29,12 @@
         <div class="mt-3 pb-5 d-flex justify-content-center">
           <div class="mx-3">
             <%= link_to '#' do %>
-              <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i> 編集</button>
+              <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i><%= (t 'defaults.to_edit') %></button>
             <% end %>
           </div>
           <div class="mx-3">
             <%= link_to '#', method: :delete, data: { confirm: (t 'defaults.message.delete_confirm') } do %>
-            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i> 削除</button>
+            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i><%= (t 'defaults.to_delete') %></button>
             <% end %>
           </div>
         </div>

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -1,5 +1,5 @@
-<div class="container-fluid bg-dark text-white">
-  <h2 class="pt-4 text-center"><%= Topic.model_name.human %></h2>
+<div class="container-fluid bg-dark text-white py-5">
+  <h2 class="text-center"><%= Topic.model_name.human %></h2>
   <%= link_to topic_path(@topic), class: 'text-decoration-none' do %>
     <div class="col-10 offset-1 p-2 d-flex justify-content-center text-center">
       <div class="row col-12">
@@ -28,7 +28,7 @@
       <%= audio_tag("#{@answer.growl_voice.url}", controls: true, id: 'js-answer-show-page-player') %>
     </div>
     <% if logged_in? && @answer.user_id == current_user.id %>
-      <div class="mt-3 pb-5 d-flex justify-content-center">
+      <div class="py-3 d-flex justify-content-center">
         <div class="mx-3">
           <%= link_to '#' do %>
             <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i><%= (t 'defaults.to_edit') %></button>

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -13,33 +13,33 @@
     </div>
   <% end %>
   <div class="flex-column">
-        <div class="mt-5 mb-3 h3 d-flex justify-content-center">
-        <%= Answer.model_name.human %>
-      </div>
-      <div class="mb-2 h4 text-break d-flex justify-content-center">
-        <%= @answer.description %>
-      </div>
-      <div class="mb-4 h5 text-break d-flex justify-content-center">
-        <% unless @answer.user.role == "guest" %>
-          <%= (t 'defaults.by') %><%= @answer.user.name %>
-        <% end %>
-      </div>
-      <div class="py-2 d-flex justify-content-center">
-        <%= audio_tag("#{@answer.growl_voice.url}", controls: true, id: 'js-answer-show-page-player') %>
-      </div>
-      <% if logged_in? && @answer.user_id == current_user.id %>
-        <div class="mt-3 pb-5 d-flex justify-content-center">
-          <div class="mx-3">
-            <%= link_to '#' do %>
-              <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i><%= (t 'defaults.to_edit') %></button>
-            <% end %>
-          </div>
-          <div class="mx-3">
-            <%= link_to '#', method: :delete, data: { confirm: (t 'defaults.message.delete_confirm') } do %>
-            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i><%= (t 'defaults.to_delete') %></button>
-            <% end %>
-          </div>
-        </div>
+    <div class="mt-5 mb-3 h3 d-flex justify-content-center">
+      <%= Answer.model_name.human %>
+    </div>
+    <div class="mb-2 h4 text-break d-flex justify-content-center">
+      <%= @answer.description %>
+    </div>
+    <div class="mb-4 h5 text-break d-flex justify-content-center">
+      <% unless @answer.user.role == "guest" %>
+        <%= (t 'defaults.by') %><%= @answer.user.name %>
       <% end %>
+    </div>
+    <div class="py-2 d-flex justify-content-center">
+      <%= audio_tag("#{@answer.growl_voice.url}", controls: true, id: 'js-answer-show-page-player') %>
+    </div>
+    <% if logged_in? && @answer.user_id == current_user.id %>
+      <div class="mt-3 pb-5 d-flex justify-content-center">
+        <div class="mx-3">
+          <%= link_to '#' do %>
+            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i><%= (t 'defaults.to_edit') %></button>
+          <% end %>
+        </div>
+        <div class="mx-3">
+          <%= link_to '#', method: :delete, data: { confirm: (t 'defaults.message.delete_confirm') } do %>
+            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i><%= (t 'defaults.to_delete') %></button>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -1,15 +1,17 @@
 <div class="container-fluid bg-dark text-white">
   <h2 class="pt-4 text-center"><%= Topic.model_name.human %></h2>
-  <div class="col-10 offset-1 p-2 d-flex justify-content-center text-center">
-    <div class="row col-12">
-      <div class="card bg-gray-color text-white border-dark p-3">
-        <div class="card-body">
-          <h4 class="card-title"><%= @topic.body %></h4>
-          <p class="card-text"><%= (t 'defaults.topic_giver') %><%= @topic.user.name %></p>
+  <%= link_to topic_path(@topic), class: 'text-decoration-none' do %>
+    <div class="col-10 offset-1 p-2 d-flex justify-content-center text-center">
+      <div class="row col-12">
+        <div class="card bg-gray-color text-white border-dark p-3">
+          <div class="card-body">
+            <h4 class="card-title"><%= @topic.body %></h4>
+            <p class="card-text"><%= (t 'defaults.topic_giver') %><%= @topic.user.name %></p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  <% end %>
   <div class="flex-column">
         <div class="mt-5 mb-3 h3 d-flex justify-content-center">
         <%= Answer.model_name.human %>

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -1,0 +1,43 @@
+<div class="container-fluid bg-dark text-white">
+  <h2 class="pt-4 text-center">お題</h2>
+  <div class="col-10 offset-1 p-2 d-flex justify-content-center text-center">
+    <div class="row col-12">
+      <div class="card bg-gray-color text-white border-dark p-3">
+        <div class="card-body">
+          <h4 class="card-title"><%= @topic.body %></h4>
+          <p class="card-text"><%= (t 'defaults.topic_giver') %><%= @topic.user.name %></p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="flex-column">
+        <div class="mt-5 mb-3 h3 d-flex justify-content-center">
+        <%= Answer.model_name.human %>
+      </div>
+      <div class="mb-2 h4 text-break d-flex justify-content-center">
+        <%= @answer.description %>
+      </div>
+      <div class="mb-4 h5 text-break d-flex justify-content-center">
+        <% unless @answer.user.role == "guest" %>
+          <%= (t 'defaults.by') %><%= @answer.user.name %>
+        <% end %>
+      </div>
+      <div class="py-2 d-flex justify-content-center">
+        <%= audio_tag("#{@answer.growl_voice.url}", controls: true, id: 'js-answer-show-page-player') %>
+      </div>
+      <% if logged_in? && @answer.user_id == current_user.id %>
+        <div class="mt-3 pb-5 d-flex justify-content-center">
+          <div class="mx-3">
+            <%= link_to '#' do %>
+              <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i> 編集</button>
+            <% end %>
+          </div>
+          <div class="mx-3">
+            <%= link_to '#', method: :delete, data: { confirm: (t 'defaults.message.delete_confirm') } do %>
+            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i> 削除</button>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+  </div>
+</div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -11,6 +11,8 @@
       <div class="py-3">
         <% if logged_in? %>
           <%= link_to (t '.to_new_topic_answer'), new_topic_answer_path(@topic), class: 'btn btn-primary justify-content-center rounded-pill my-4' %>
+        <% else %>
+          <h5 class="my-4"><%= (t '.please_login_to_answer_the_topic') %></h5>
         <% end %>
       </div>
     </div>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -19,12 +19,12 @@
         <div class="pb-5 d-flex justify-content-center">
           <div class="mx-3">
             <%= link_to edit_voice_path(@voice) do %>
-              <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i> <%= (t '.to_edit') %></button>
+              <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i><%= (t 'defaults.to_edit') %></button>
             <% end %>
           </div>
           <div class="mx-3">
             <%= link_to voice_path(@voice), method: :delete, data: { confirm: (t 'defaults.message.delete_confirm') } do %>
-            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i> <%= (t '.to_delete') %></button>
+            <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i><%= (t 'defaults.to_delete') %></button>
             <% end %>
           </div>
         </div>

--- a/app/views/voices/show.html.erb
+++ b/app/views/voices/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container-fluid bg-dark text-white">
   <div class="d-flex justify-content-center text-center">
-    <div>
+    <div class="flex-column">
       <div class="mt-5 mb-4 h3">
         <%= Voice.human_attribute_name(:description) %>
       </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -21,6 +21,8 @@ ja:
     reset: '取り直す'
     by: 'By '
     topic_giver: '出題者 '
+    to_edit: ' 編集'
+    to_delete: ' 削除'
     message:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成できませんでした"
@@ -48,9 +50,6 @@ ja:
       title: '録音・加工する'
       save_as_logged_in_user: '保存してシェア画面へ'
       to_share: 'シェア画面へ'
-    show:
-      to_edit: '編集'
-      to_delete: '削除'
     edit:
       title: '編集'
       update_button: '更新する'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -67,6 +67,7 @@ ja:
       topic_not_found_message: 'まだお題は投稿されていません'
     show:
       to_new_topic_answer: 'お題に回答'
+      please_login_to_answer_the_topic: '※お題に回答するにはログインが必要です'
   answers:
     new:
       title: 'お題に回答！'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,6 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   resources :voices
   resources :topics, only: %i[new create index show] do
-    resources :answers, only: %i[new create]
+    resources :answers, only: %i[new create show]
   end
 end


### PR DESCRIPTION
## 概要
回答詳細ページを作成しました。
回答の音声情報だけでなく、紐づいているお題の情報も表示しています。
お題を表示しているカードをクリックするとそのお題の詳細ページへ遷移するようにリンクを設定しました。
回答録音ページで回答の保存が成功した時作成した回答の詳細ページへ遷移するようにしました。
詳細に表示されている回答の作成者にのみ編集ボタンと削除ボタンを表示するようにしました。リンク先は未設定です。
その他音声詳細ページやお題詳細ページのレイアウト等の調整も行いました。

close #71 

## 確認方法
1. 自分が作成した回答の詳細ページにアクセスするとお題と回答の情報に加えて、編集ボタンと削除ボタンも表示されること、お題のカードをクリックするとお題詳細ページへ遷移することを確認してください。
2. それ以外の回答詳細ページでは編集ボタンと削除ボタンは表示されないことを確認してください。
3. ログインしていない状態でお題詳細ページへアクセスするとお題とともに「※お題に回答するにはログインが必要です」と表示されることを確認してください。
4. ログインして、回答を作成した場合その回答詳細画面へ遷移することを確認してください。

## コメント
d271a73 に関してですが、このように変更を加えた経緯を以下でまとめています。
[回答録音は成功しているがUnpermitted parameter: :topic_idとサーバーログに出る](https://ripe-kayak-b03.notion.site/Unpermitted-parameter-topic_id-90e2972e44284158a5b2468a46216d2c)
