### PR TITLE
回答編集・削除機能を実装

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,5 +1,5 @@
 class AnswersController < ApplicationController
-  before_action :require_login, only: %i[new]
+  before_action :require_login, only: %i[new create edit update destroy]
 
   def new
     @topic = Topic.find(params[:topic_id])
@@ -21,9 +21,33 @@ class AnswersController < ApplicationController
     end
   end
 
+  def edit
+    @topic = Topic.find(params[:topic_id])
+    @answer = current_user.answers.find(params[:id])
+  end
+
+  def update
+    @topic = Topic.find(params[:topic_id])
+    @answer = current_user.answers.find(params[:id])
+
+    if @answer.update(answer_params_for_update)
+      redirect_to topic_answer_path(@topic, @answer), dark: '更新しました'
+    else
+      flash.now[:danger] = '更新に失敗しました'
+      render :edit
+    end
+  end
+
+  def destroy
+  end
+
   private
 
   def answer_params
     params.permit(:growl_voice, :description, :topic_id)
+  end
+
+  def answer_params_for_update
+    params.require(:answer).permit(:description)
   end
 end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -31,9 +31,9 @@ class AnswersController < ApplicationController
     @answer = current_user.answers.find(params[:id])
 
     if @answer.update(answer_params_for_update)
-      redirect_to topic_answer_path(@topic, @answer), dark: '更新しました'
+      redirect_to topic_answer_path(@topic, @answer), dark: (t 'defaults.message.updated', item: Answer.human_attribute_name(:description))
     else
-      flash.now[:danger] = '更新に失敗しました'
+      flash.now[:danger] = (t 'defaults.message.not_updated', item: Answer.human_attribute_name(:description))
       render :edit
     end
   end
@@ -43,7 +43,7 @@ class AnswersController < ApplicationController
     @answer = current_user.answers.find(params[:id])
 
     @answer.destroy
-    redirect_to @topic
+    redirect_to @topic, dark: (t 'defaults.message.deleted', item: Answer.model_name.human)
   end
 
   private

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -39,6 +39,11 @@ class AnswersController < ApplicationController
   end
 
   def destroy
+    @topic = Topic.find(params[:topic_id])
+    @answer = current_user.answers.find(params[:id])
+
+    @answer.destroy
+    redirect_to @topic
   end
 
   private

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,5 +1,5 @@
 class TopicsController < ApplicationController
-  before_action :require_login, only: %i[new]
+  before_action :require_login, only: %i[new create]
 
   def new
     @topic = current_user.topics.build

--- a/app/views/answers/edit.html.erb
+++ b/app/views/answers/edit.html.erb
@@ -2,15 +2,15 @@
   <h2 class="pt-5 pb-3 d-flex justify-content-center text-center"><%= (t '.title') %></h2>
   <h4 class="text-center"><%= Topic.model_name.human %></h4>
   <div class="col-10 offset-1 pt-2 pb-4 d-flex justify-content-center text-center">
-      <div class="row col-12">
-        <div class="card bg-gray-color text-white border-dark p-3">
-          <div class="card-body">
-            <h4 class="card-title"><%= @topic.body %></h4>
-            <p class="card-text"><%= (t 'defaults.topic_giver') %><%= @topic.user.name %></p>
-          </div>
+    <div class="row col-12">
+      <div class="card bg-gray-color text-white border-dark p-3">
+        <div class="card-body">
+          <h4 class="card-title"><%= @topic.body %></h4>
+          <p class="card-text"><%= (t 'defaults.topic_giver') %><%= @topic.user.name %></p>
         </div>
       </div>
     </div>
+  </div>
   <div class="d-flex justify-content-center mb-4">
     <%= audio_tag("#{@answer.growl_voice.url}", controls: true, id: 'js-answer-edit-page-player') %>
   </div>

--- a/app/views/answers/edit.html.erb
+++ b/app/views/answers/edit.html.erb
@@ -1,0 +1,17 @@
+<div class="container-fluid bg-dark text-white">
+  <h2 class="py-5 d-flex justify-content-center text-center">回答編集</h2>
+  <div class="d-flex justify-content-center mb-5">
+    <%= audio_tag("#{@answer.growl_voice.url}", controls: true, id: 'js-answer-edit-page-player') %>
+  </div>
+  <div class="mb-4 h5 text-break text-center">
+    <%= (t 'defaults.by') %><%= @answer.user.name %>
+  </div>
+  <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3 pb-4">
+    <%= form_with model: [@topic, @answer], local: true do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
+      <%= f.label :description, Answer.human_attribute_name(:description) %>
+      <%= f.text_field :description, class: 'form-control' %>
+      <%= f.submit '更新する', class: 'btn btn-primary d-block mx-auto rounded-pill my-4' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/answers/edit.html.erb
+++ b/app/views/answers/edit.html.erb
@@ -1,6 +1,17 @@
 <div class="container-fluid bg-dark text-white">
-  <h2 class="py-5 d-flex justify-content-center text-center"><%= (t '.title') %></h2>
-  <div class="d-flex justify-content-center mb-5">
+  <h2 class="pt-5 pb-3 d-flex justify-content-center text-center"><%= (t '.title') %></h2>
+  <h4 class="text-center"><%= Topic.model_name.human %></h4>
+  <div class="col-10 offset-1 pt-2 pb-4 d-flex justify-content-center text-center">
+      <div class="row col-12">
+        <div class="card bg-gray-color text-white border-dark p-3">
+          <div class="card-body">
+            <h4 class="card-title"><%= @topic.body %></h4>
+            <p class="card-text"><%= (t 'defaults.topic_giver') %><%= @topic.user.name %></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  <div class="d-flex justify-content-center mb-4">
     <%= audio_tag("#{@answer.growl_voice.url}", controls: true, id: 'js-answer-edit-page-player') %>
   </div>
   <div class="mb-4 h5 text-break text-center">

--- a/app/views/answers/edit.html.erb
+++ b/app/views/answers/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid bg-dark text-white">
-  <h2 class="py-5 d-flex justify-content-center text-center">回答編集</h2>
+  <h2 class="py-5 d-flex justify-content-center text-center"><%= (t '.title') %></h2>
   <div class="d-flex justify-content-center mb-5">
     <%= audio_tag("#{@answer.growl_voice.url}", controls: true, id: 'js-answer-edit-page-player') %>
   </div>
@@ -11,7 +11,7 @@
       <%= render 'shared/error_messages', object: f.object %>
       <%= f.label :description, Answer.human_attribute_name(:description) %>
       <%= f.text_field :description, class: 'form-control' %>
-      <%= f.submit '更新する', class: 'btn btn-primary d-block mx-auto rounded-pill my-4' %>
+      <%= f.submit (t 'defaults.update_button'), class: 'btn btn-primary d-block mx-auto rounded-pill my-4' %>
     <% end %>
   </div>
 </div>

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -35,7 +35,7 @@
           <% end %>
         </div>
         <div class="mx-3">
-          <%= link_to '#', method: :delete, data: { confirm: (t 'defaults.message.delete_confirm') } do %>
+          <%= link_to topic_answer_path(@topic, @answer), method: :delete, data: { confirm: (t 'defaults.message.delete_confirm') } do %>
             <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-trash"></i><%= (t 'defaults.to_delete') %></button>
           <% end %>
         </div>

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -30,7 +30,7 @@
     <% if logged_in? && @answer.user_id == current_user.id %>
       <div class="py-3 d-flex justify-content-center">
         <div class="mx-3">
-          <%= link_to '#' do %>
+          <%= link_to edit_topic_answer_path(@topic, @answer) do %>
             <button class="btn btn-primary mx-auto rounded-pill"><i class="fas fa-pen"></i><%= (t 'defaults.to_edit') %></button>
           <% end %>
         </div>

--- a/app/views/voices/edit.html.erb
+++ b/app/views/voices/edit.html.erb
@@ -13,7 +13,7 @@
       <%= render 'shared/error_messages', object: f.object %>
       <%= f.label :description, Voice.human_attribute_name(:description) %>
       <%= f.text_field :description, class: 'form-control' %>
-      <%= f.submit (t '.update_button'), class: 'btn btn-primary d-block mx-auto rounded-pill my-4' %>
+      <%= f.submit (t 'defaults.update_button'), class: 'btn btn-primary d-block mx-auto rounded-pill my-4' %>
     <% end %>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -23,6 +23,7 @@ ja:
     topic_giver: '出題者 '
     to_edit: ' 編集'
     to_delete: ' 削除'
+    update_button: '更新する'
     message:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成できませんでした"
@@ -52,7 +53,6 @@ ja:
       to_share: 'シェア画面へ'
     edit:
       title: '編集'
-      update_button: '更新する'
     index:
       voice_not_found_message: 'まだ音声がありません...ぜひ使ってみてね！'
   topics:
@@ -72,6 +72,8 @@ ja:
     new:
       title: 'お題に回答！'
       post: '投稿する'
+    edit:
+      title: '回答編集'
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,6 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   resources :voices
   resources :topics, only: %i[new create index show] do
-    resources :answers, only: %i[new create show]
+    resources :answers, only: %i[new create show edit update destroy]
   end
 end


### PR DESCRIPTION
## 概要
回答編集ページを作成し、回答の「内容」を編集できるようにしました。
デスボイスの録り直しには対応していません。
回答詳細画面の編集ボタン・削除ボタンにそれぞれリンク先を設定しました。
削除ボタンを押すと削除できるようにしました。
その他、voicesコントローラーを見直しrequire_loginのコールバックにcreateアクションも追加しました。 8f9e38a 

close #72 

## 確認方法
1. ログインしている場合、自分が作成した回答の詳細画面に編集ボタンを押すと編集ページへ遷移することを確認してください。
2. 編集ページで内容が入力された状態で更新するボタンを押すと編集が完了し、回答詳細ページへ遷移、フラッシュメッセージが表示されることを確認してください。
3. 編集ページで内容を入力せず更新ボタンを押すと、エラーメッセージとフラッシュメッセージが表示され編集画面が再描画されることを確認してください。
4. 自分が作成した回答詳細ページで削除ボタンを押しconfirmを受け容れると、削除が完了しお題詳細ページに遷移しフラッシュメッセージが表示されることを確認してください。

## コメント
実装中に出てきた疑問についてまとめています。
[疑問: 「作成者のみ編集・削除可能にする」ための方法に関して](https://ripe-kayak-b03.notion.site/b7676163677b45ecbd9b13d288bee311)
ここに記載した通り現在のままでも期待する動作はしているので、暫定的にこのままプルリクをあげ、引き続き検証を行い問題があるとわかった場合にIssueを立てて対応します。