### PR TITLE
お題詳細ページにそのお題に紐づく回答一覧を表示

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -7,6 +7,7 @@ class TopicsController < ApplicationController
 
   def show
     @topic = Topic.find(params[:id])
+    @pagy, @answers = pagy(Answer.where(topic_id: @topic.id).includes(:user).order(created_at: :desc))
   end
 
   def index

--- a/app/views/topics/_answer.html.erb
+++ b/app/views/topics/_answer.html.erb
@@ -1,0 +1,14 @@
+<div class="container-fluid">
+  <div class="m-2">
+    <div class="answer-id-<%= answer.id %>">
+      <%= link_to topic_answer_path(topic, answer), class: 'text-decoration-none' do %>
+        <div class="card bg-gray-color text-white border-dark p-3">
+          <div class="card-body">
+            <h4 class="card-title"><%= answer.description %></h4>
+            <p class="card-text"><%= (t 'defaults.by') %><%= answer.user.name %></p>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -17,4 +17,19 @@
       </div>
     </div>
   </div>
+  <div class="col-10 offset-1 d-flex justify-content-center text-center pb-5">
+    <div class="row col-12">
+      <h2 class="pb-3">回答</h2>
+      <% if @answers.present? %>
+        <% @answers.each do |answer| %>
+          <%= render 'answer', answer: answer, topic: @topic %>
+        <% end %>
+      <% else %>
+        <h5>まだ投稿がありません</h5>
+      <% end %>
+      <div class="d-flex justify-content-center mt-3">
+        <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -19,13 +19,13 @@
   </div>
   <div class="col-10 offset-1 d-flex justify-content-center text-center pb-5">
     <div class="row col-12">
-      <h2 class="pb-3">回答</h2>
+      <h2 class="pb-3"><%= Answer.model_name.human %></h2>
       <% if @answers.present? %>
         <% @answers.each do |answer| %>
           <%= render 'answer', answer: answer, topic: @topic %>
         <% end %>
       <% else %>
-        <h5>まだ投稿がありません</h5>
+        <h5><%= (t '.answer_not_found_message') %></h5>
       <% end %>
       <div class="d-flex justify-content-center mt-3">
         <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -68,6 +68,7 @@ ja:
     show:
       to_new_topic_answer: 'お題に回答'
       please_login_to_answer_the_topic: '※お題に回答するにはログインが必要です'
+      answer_not_found_message: 'まだ投稿がありません…ぜひ気軽に回答してみてね！'
   answers:
     new:
       title: 'お題に回答！'


### PR DESCRIPTION
## 概要
お題詳細ページにそのお題に紐づく回答一覧を表示させました。

close #77 

## 確認方法
1. お題に紐づく回答が存在しない場合にお題詳細へアクセスすると、まだ投稿がないという文言が表示されることを確認してください。
2. お題に紐づく回答が存在する場合、お題詳細ページにそのお題に紐づく回答が一覧表示されることを確認してください。
3. お題に紐づく回答が11件以上存在する場合はページネーションのナビゲーションが表示されることを確認してください。

