### PR TITLE
お題一覧ページにログインユーザーにのみお題投稿ページへのリンクを表示

### DIFF
--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,6 +1,9 @@
-<div class="container-fluid bg-dark text-white">
-    <h2 class="pt-5 text-center"><%= (t '.title') %></h2>
-  <div class="col-10 offset-1 py-5 d-flex justify-content-center text-center">
+<div class="container-fluid bg-dark text-white text-center py-5">
+    <h2 ><%= (t '.title') %></h2>
+    <% if logged_in? %>
+      <%= link_to (t '.to_new_topic'), new_topic_path, class: 'btn btn-primary mx-auto rounded-pill my-3' %>
+    <% end %>
+  <div class="col-10 offset-1 d-flex justify-content-center text-center">
     <div class="row col-12">
       <% if @topics.present? %>
         <%= render @topics %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -70,6 +70,7 @@ ja:
       notice_about_post: '※お題は投稿された後では編集・削除ができません。よく確認してからご投稿ください。'
     index:
       title: '〜お題一覧〜'
+      to_new_topic: 'お題を投稿する'
       topic_not_found_message: 'まだお題は投稿されていません'
     show:
       to_new_topic_answer: 'お題に回答'


### PR DESCRIPTION
## 概要
お題一覧ページに、お題投稿ページへのリンクとなっているボタンをログインユーザーにのみ表示するようにしました。

close #85 

## 確認方法
1. ログインしていない状態でお題一覧`/topics`にアクセスしたときお題を投稿するボタンが表示されないことを確認してください。
2. ログインして`/topics`にアクセスするとお題を投稿するボタンが表示されていること、ボタンを押すとお題投稿ページへ遷移することを確認してください。