### PR TITLE
マイページでユーザー情報を編集できる機能を実装

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,8 +1,29 @@
 class MypagesController < ApplicationController
-  before_action :require_login, only: %i[show]
+  before_action :require_login, only: %i[show edit create]
 
   def show
     @pagy_voices, @voices = pagy(current_user.voices.order(created_at: :desc), page_param: :page_voices)
     @pagy_answers, @answers = pagy(current_user.answers.includes(:topic).order(created_at: :desc), page_param: :page_answers)
+  end
+
+  def edit
+    @user = User.find(current_user.id)
+  end
+
+  def update
+    @user = User.find(current_user.id)
+
+    if @user.update(user_params)
+      redirect_to mypage_path, dark: 'ユーザー情報を更新しました'
+    else
+      flash.now[:danger] = 'ユーザー情報の更新に失敗しました'
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email)
   end
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -14,9 +14,9 @@ class MypagesController < ApplicationController
     @user = User.find(current_user.id)
 
     if @user.update(user_params)
-      redirect_to mypage_path, dark: 'ユーザー情報を更新しました'
+      redirect_to mypage_path, dark: (t 'defaults.message.updated', item: (t 'defaults.user_data'))
     else
-      flash.now[:danger] = 'ユーザー情報の更新に失敗しました'
+      flash.now[:danger] = (t 'defaults.message.not_updated', item: (t 'defaults.user_data'))
       render :edit
     end
   end

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -1,12 +1,12 @@
 <div class="container-fluid bg-dark text-white text-center py-5">
-  <h2>ユーザー情報編集</h2>
+  <h2><%= (t '.title') %></h2>
   <div class="col-12 col-md-10 offset-md-1 col-lg-8 offset-lg-2 py-5">
     <%= form_with model: @user, url: mypage_path, local: true do |f| %>
       <%= f.label :name, User.human_attribute_name(:name) %>
       <%= f.text_field :name, class: 'form-control' %>
       <%= f.label :email, User.human_attribute_name(:email) %>
       <%= f.email_field :email, class: 'form-control' %>
-      <%= f.submit '更新する', class: 'btn btn-primary rounded-pill mx-auto my-3' %>
+      <%= f.submit (t 'defaults.update_button'), class: 'btn btn-primary rounded-pill mx-auto my-3' %>
     <% end %>
   </div>
 </div>

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -1,12 +1,12 @@
-<div class="container-fluid bg-dark text-white text-center py-5">
-  <h2><%= (t '.title') %></h2>
-  <div class="col-12 col-md-10 offset-md-1 col-lg-8 offset-lg-2 py-5">
+<div class="container-fluid bg-dark text-white py-5">
+  <div class="col-12 col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+    <h2 class='text-center pb-5'><%= (t '.title') %></h2>
     <%= form_with model: @user, url: mypage_path, local: true do |f| %>
       <%= f.label :name, User.human_attribute_name(:name) %>
       <%= f.text_field :name, class: 'form-control' %>
       <%= f.label :email, User.human_attribute_name(:email) %>
       <%= f.email_field :email, class: 'form-control' %>
-      <%= f.submit (t 'defaults.update_button'), class: 'btn btn-primary rounded-pill mx-auto my-3' %>
+      <%= f.submit (t 'defaults.update_button'), class: 'btn btn-primary rounded-pill d-block mx-auto my-3' %>
     <% end %>
   </div>
 </div>

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -1,0 +1,12 @@
+<div class="container-fluid bg-dark text-white text-center py-5">
+  <h2>ユーザー情報編集</h2>
+  <div class="col-12 col-md-10 offset-md-1 col-lg-8 offset-lg-2 py-5">
+    <%= form_with model: @user, url: mypage_path, local: true do |f| %>
+      <%= f.label :name, User.human_attribute_name(:name) %>
+      <%= f.text_field :name, class: 'form-control' %>
+      <%= f.label :email, User.human_attribute_name(:email) %>
+      <%= f.email_field :email, class: 'form-control' %>
+      <%= f.submit '更新する', class: 'btn btn-primary rounded-pill mx-auto my-3' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -2,6 +2,7 @@
   <div class="col-12 col-md-10 offset-md-1 col-lg-8 offset-lg-2">
     <h2 class='text-center pb-5'><%= (t '.title') %></h2>
     <%= form_with model: @user, url: mypage_path, local: true do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
       <%= f.label :name, User.human_attribute_name(:name) %>
       <%= f.text_field :name, class: 'form-control' %>
       <%= f.label :email, User.human_attribute_name(:email) %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,6 +8,7 @@ ja:
     voices_list: 'デスボ一覧'
     topics_list: 'お題一覧'
     my_page: 'マイページ'
+    user_data: 'ユーザー情報'
     terms_of_services: '利用規約'
     privacy_policy: 'プライバシーポリシー'
     inquiry: 'お問い合わせ'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -90,6 +90,8 @@ ja:
       caution_about_topics: 'お題に関しては原則として投稿したユーザーであっても変更できません。ご要望がありましたらアプリ製作者へご連絡お願いいたします。'
       leave_confirm: '本当に退会しますか？'
       leave_button: '退会する'
+    edit:
+      title: 'ユーザー情報編集'
   static_pages:
     top:
       catch_phrase: 'デスボをあなたのとなりに'


### PR DESCRIPTION
## 概要
マイページ編集画面を作成し、ユーザーの名前とメールアドレスを編集できるようにしました。
パスワードはセキュリティを考慮し、パスワードリセット機能で変更できるようにします。これは別Issueで対応します。

close #84 

## 確認方法
1. ログインし、`/mypage/edit`へアクセスしてください。
2. 更新するボタンを押したとき、バリデーションエラーで保存に失敗するとフラッシュメッセージとエラーメッセージが表示されることを確認してください。
3. 更新に成功するとマイページ詳細画面(`/mypage`)に遷移し、フラッシュメッセージが表示され、表示されているユーザー名とメールアドレスが更新されていることを確認してください。