### PR TITLE
metaタグのOGPの表示のための設定の必須項目が抜けていたため追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,7 @@ module ApplicationHelper
       ],
       og: {
         site_name: :site,
+        title: :site,
         description: :description,
         type: 'website',
         url: :canonical,


### PR DESCRIPTION
## 概要
原因と解決方法などの詳細はIssue #101 に記述しました。
`default_meta_tags`メソッドのOGPの表示に必要な設定である、titleを指定し忘れていたため、Twitterに限らずOGPの設定が正しくできていませんでした。
ogのtitleにアプリ名を指定しました。
開発環境でOGPの表示を確認できる拡張機能・Social Share Previewを使用し、OGPの表示を確認しました。
問題なく設定できているようです。
![image](https://user-images.githubusercontent.com/87419889/179384080-53bb2e3c-0c0f-43e0-9c98-6df8fc054f3b.png)


close #101 
