### PR TITLE
アプリ機能の説明不足へ対応

### DIFF
--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -26,10 +26,10 @@
     <button id="js-reset-button" class="btn btn-primary rounded-pill d-none"><%= (t 'defaults.reset') %></button>
   </div>
 
-  <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
+  <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3 py-4">
     <%= form_with url: topic_answers_path(@topic), id: 'answer-form', local: true do |f| %>
       <%= f.hidden_field :growl_voice %>
-      <%= f.label :description, Answer.human_attribute_name(:description) %>
+      <%= f.label :description, '内容 ※音声にタイトルをつけるとしたら？' %>
       <%= f.text_field :description, class: 'form-control', id: 'description-form' %>
     <% end %>
   </div>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid bg-dark text-white text-center py-5">
-    <h2 ><%= (t '.title') %></h2>
+    <h2><%= (t '.title') %></h2>
     <% if logged_in? %>
       <%= link_to (t '.to_new_topic'), new_topic_path, class: 'btn btn-primary mx-auto rounded-pill my-3' %>
     <% end %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,8 +1,8 @@
 <div class="container-fluid bg-dark text-white text-center py-5">
     <h2><%= (t '.title') %></h2>
     <div class="py-4">
-      <h5>お題にデスボイスで答える大喜利です。</h5>
-      <p>※ログインするとお題と回答を投稿できます。</p>
+      <h5><%= (t '.topics_description') %></h5>
+      <p><%= (t '.notice_about_topics') %></p>
     </div>
     <% if logged_in? %>
       <%= link_to (t '.to_new_topic'), new_topic_path, class: 'btn btn-primary mx-auto rounded-pill mt-1 mb-5' %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,7 +1,11 @@
 <div class="container-fluid bg-dark text-white text-center py-5">
     <h2><%= (t '.title') %></h2>
+    <div class="py-4">
+      <h5>お題にデスボイスで答える大喜利です。</h5>
+      <p>※ログインするとお題と回答を投稿できます。</p>
+    </div>
     <% if logged_in? %>
-      <%= link_to (t '.to_new_topic'), new_topic_path, class: 'btn btn-primary mx-auto rounded-pill my-3' %>
+      <%= link_to (t '.to_new_topic'), new_topic_path, class: 'btn btn-primary mx-auto rounded-pill mt-1 mb-5' %>
     <% end %>
   <div class="col-10 offset-1 d-flex justify-content-center text-center">
     <div class="row col-12">

--- a/app/views/voices/new.html.erb
+++ b/app/views/voices/new.html.erb
@@ -19,7 +19,7 @@
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
     <%= form_with url: voices_path, local: true do |f| %>
       <%= f.hidden_field :growl_voice %>
-      <%= f.label :description, Voice.human_attribute_name(:description) %>
+      <%= f.label :description, '内容 ※音声にタイトルをつけるとしたら？' %>
       <%= f.text_field :description, class: 'form-control', id: 'description-form' %>
     <% end %>
   </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -74,7 +74,7 @@ ja:
       description_for_topics: 'デスボイスで言ったら面白そうな言葉や、こんな時デスボイスでどう返す？といったお題を投稿できます。'
       notice_about_post: '※お題は投稿された後では編集・削除ができません。よく確認してからご投稿ください。'
     index:
-      title: '〜お題一覧〜'
+      title: '大喜利！お題で「吠えて！」'
       to_new_topic: 'お題を投稿する'
       topic_not_found_message: 'まだお題は投稿されていません'
     show:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -75,6 +75,8 @@ ja:
       notice_about_post: '※お題は投稿された後では編集・削除ができません。よく確認してからご投稿ください。'
     index:
       title: '大喜利！お題で「吠えて！」'
+      topics_description: 'お題にデスボイスで答える大喜利です。'
+      notice_about_topics: '※ログインするとお題と回答を投稿できます。'
       to_new_topic: 'お題を投稿する'
       topic_not_found_message: 'まだお題は投稿されていません'
     show:


### PR DESCRIPTION
## 概要
録音ページの内容の欄に何を入力するべきなのかわかりにくいかもというフィードバックへ対応しました。
内容のラベルに「※音声にタイトルをつけるとしたら？」という文言を追加しました。
お題一覧が大喜利のお題だとわかりにくいため、タイトルを『大喜利！お題で「吠えて！」』と変更しました。
また大喜利の趣旨を説明も追加しました。

close #98 
close #106 

## 確認方法
1. 音声録音ページと回答録音ページの内容入力欄に「※音声にタイトルをつけるとしたら？」という注釈が表示されていることを確認してください。
2. お題一覧画面のタイトルの表示が変更されているか、説明が新たに表示されているかを確認してください。
