### PR TITLE
音声・回答保存失敗時にエラーメッセージを表示

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -15,9 +15,9 @@ class AnswersController < ApplicationController
     answer = current_user.answers.build(answer_params)
 
     if answer.save
-      render json: { url: topic_answer_path(topic, answer) }
+      render json: { url: topic_answer_path(topic, answer), result: 'success' }
     else
-      render json: { url: new_topic_answer_path(topic) }
+      render json: { result: 'failed' }
     end
   end
 

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -27,7 +27,7 @@ class VoicesController < ApplicationController
     if voice.save
       render json: { url: voice_path(voice), result: 'success' }
     else
-      render json: { url: new_voice_path, result: 'failed' }
+      render json: { result: 'failed' }
     end
   end
 

--- a/app/controllers/voices_controller.rb
+++ b/app/controllers/voices_controller.rb
@@ -25,9 +25,9 @@ class VoicesController < ApplicationController
     end
 
     if voice.save
-      render json: { url: voice_path(voice) }
+      render json: { url: voice_path(voice), result: 'success' }
     else
-      render json: { url: new_voice_path }
+      render json: { url: new_voice_path, result: 'failed' }
     end
   end
 

--- a/app/javascript/packs/recording.js
+++ b/app/javascript/packs/recording.js
@@ -265,7 +265,16 @@ jsVoiceSaveButton.onclick = function() {
       }
     }).then(response => {
       let data = response.data;
-      window.location.href = data.url;
+      if(data.result == 'failed') {
+        document.getElementById('js-error-message').innerHTML = '<div class="alert alert-danger">' +
+                                                                '<ul class="error-message-list">' +
+                                                                '<li>内容を入力してください</li>' +
+                                                                '</ul>' +
+                                                                '</div>' ;
+        jsVoiceSaveButton.disabled = false;
+      }else{
+        window.location.href = data.url;
+      }
     }).catch(error => {
       console.log(error.response);
     });

--- a/app/javascript/packs/recording.js
+++ b/app/javascript/packs/recording.js
@@ -266,7 +266,7 @@ jsVoiceSaveButton.onclick = function() {
     }).then(response => {
       let data = response.data;
       if(data.result == 'failed') {
-        document.getElementById('js-error-message').innerHTML = '<div class="alert alert-danger">' +
+        document.getElementById('js-voice-error-message').innerHTML = '<div class="alert alert-danger">' +
                                                                 '<ul class="error-message-list">' +
                                                                 '<li>内容を入力してください</li>' +
                                                                 '</ul>' +

--- a/app/javascript/packs/recording_answers.js
+++ b/app/javascript/packs/recording_answers.js
@@ -265,7 +265,16 @@ jsAnswerSaveButton.onclick = function() {
       }
     }).then(response => {
       let data = response.data;
-      window.location.href = data.url;
+      if(data.result == 'failed') {
+        document.getElementById('js-answer-error-message').innerHTML = '<div class="alert alert-danger">' +
+                                                                '<ul class="error-message-list">' +
+                                                                '<li>内容を入力してください</li>' +
+                                                                '</ul>' +
+                                                                '</div>' ;
+        jsAnswerSaveButton.disabled = false;
+      }else{
+        window.location.href = data.url;
+      }
     }).catch(error => {
       console.log(error.response);
     });

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -28,6 +28,7 @@
 
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3 py-4">
     <%= form_with url: topic_answers_path(@topic), id: 'answer-form', local: true do |f| %>
+      <div id="js-answer-error-message"></div>
       <%= f.hidden_field :growl_voice %>
       <%= f.label :description, '内容 ※音声にタイトルをつけるとしたら？' %>
       <%= f.text_field :description, class: 'form-control', id: 'description-form' %>

--- a/app/views/voices/new.html.erb
+++ b/app/views/voices/new.html.erb
@@ -18,6 +18,7 @@
 
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
     <%= form_with url: voices_path, local: true do |f| %>
+      <div id="js-error-message"></div>
       <%= f.hidden_field :growl_voice %>
       <%= f.label :description, '内容 ※音声にタイトルをつけるとしたら？' %>
       <%= f.text_field :description, class: 'form-control', id: 'description-form' %>

--- a/app/views/voices/new.html.erb
+++ b/app/views/voices/new.html.erb
@@ -18,7 +18,7 @@
 
   <div class="col-10 offset-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
     <%= form_with url: voices_path, local: true do |f| %>
-      <div id="js-error-message"></div>
+      <div id="js-voice-error-message"></div>
       <%= f.hidden_field :growl_voice %>
       <%= f.label :description, '内容 ※音声にタイトルをつけるとしたら？' %>
       <%= f.text_field :description, class: 'form-control', id: 'description-form' %>


### PR DESCRIPTION
## 概要
音声録音画面と回答録音画面で保存失敗時に「内容を入力してください」とエラーメッセージを表示するようにしました。
本来であれば、Controller側で保存失敗時に発生したエラー内容をjsonでそのままフロントへ渡し、エラーメッセージとして動的に出力するのがベストかと思いますが、
今回の場合、音声データを録音後でなければ保存ボタンが表示されず、また押すこともできないようにしているので、エラーとして発生しうるのは「内容」が未入力の場合のみであるので、この実装で当面は事足りると判断しました。
動的に出力することは今後の課題として新たにIssueを作成し、対応予定です。

close #43 

## 確認方法
1. 音声録音ページへアクセスし、音声を録音し「内容」を入力せずに保存ボタンを押します。
2. エラメッセージとして「内容を入力してください」と表示されることを確認してください。
3. 回答録音ページに関しても同様に確認してください。

## コメント
非同期通信でフラッシュメッセージを実装するのは比較的難易度が高く、
エラメッセージを実装できた時点で、最低限ではありますがユーザーにわかりやすいものとなったため、
リリース予定が迫っていることもあり、
このプルリクエストでは対応せず他にIssueを立てて対応します。

**参考記事**
[Ajax でも Rails の flash メッセージを表示したい！](https://qiita.com/QUANON/items/979a0b918cf560c9322e)