### PR TITLE
バリデーションエラー時に文字数制限も表示

### DIFF
--- a/app/javascript/packs/recording.js
+++ b/app/javascript/packs/recording.js
@@ -268,7 +268,7 @@ jsVoiceSaveButton.onclick = function() {
       if(data.result == 'failed') {
         document.getElementById('js-voice-error-message').innerHTML = '<div class="alert alert-danger">' +
                                                                 '<ul class="error-message-list">' +
-                                                                '<li>内容を入力してください</li>' +
+                                                                '<li>内容を30字以内で入力してください</li>' +
                                                                 '</ul>' +
                                                                 '</div>' ;
         jsVoiceSaveButton.disabled = false;

--- a/app/javascript/packs/recording_answers.js
+++ b/app/javascript/packs/recording_answers.js
@@ -268,7 +268,7 @@ jsAnswerSaveButton.onclick = function() {
       if(data.result == 'failed') {
         document.getElementById('js-answer-error-message').innerHTML = '<div class="alert alert-danger">' +
                                                                 '<ul class="error-message-list">' +
-                                                                '<li>内容を入力してください</li>' +
+                                                                '<li>内容を30字以内で入力してください</li>' +
                                                                 '</ul>' +
                                                                 '</div>' ;
         jsAnswerSaveButton.disabled = false;


### PR DESCRIPTION
## 概要
応急処置的に、音声と回答のバリデーションエラー時は一律で「内容は30字以内で入力してください」と表示されるよう変更
本格的に対処するのは #118 で予定。

close #123 